### PR TITLE
Fix non-compiling code examples in error-handling docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ To use these custom guards, `import` or `require` the `Errata` module.
 The following example demonstrates handling Errata errors both as raised
 exceptions and as error values returned from functions.
 
+> #### `rescue` clauses and the custom guards {: .info}
+>
+> Elixir's `rescue` clauses only accept a bare variable or the
+> `var in [ExceptionModule]` form; they do **not** accept arbitrary `when`
+> guards. To use the `Errata.is_error/1` family when rescuing, rescue the
+> exception into a variable and then dispatch on it (for example with
+> `cond/1`), as shown below. The guards _can_ be used directly in the `when`
+> clause of a `case`, `with`, or function head when handling errors returned
+> as values.
+
 ```elixir
 defmodule MyApp.SomeContext do
   # require the Errata module to use the custom guards
@@ -141,14 +151,15 @@ defmodule MyApp.SomeContext do
         # Errata errors can be rescued by their specific type
         handle_my_domain_error(e)
 
-      e when Errata.is_error(e) ->
-        # Or they can be rescued using one of the custom guards defined in the
-        # Errata module
-        handle_errata_error(e)
-
       e ->
-        # Regular exceptions may be handled separately if desired
-        handle_other_error(e)
+        # `rescue` clauses cannot use `when` guards, so rescue the exception
+        # and then dispatch on it using the custom guards defined in the
+        # Errata module
+        cond do
+          Errata.is_error(e) -> handle_errata_error(e)
+          # Regular exceptions may be handled separately if desired
+          true -> handle_other_error(e)
+        end
     end
   end
 
@@ -163,8 +174,8 @@ defmodule MyApp.SomeContext do
 
       {:error, error} when Errata.is_error(error) ->
         # Or they can be identified using one of the custom guards defined in
-        # the Errata module
-        handle_errata_error(e)
+        # the Errata module (`when` guards are allowed in `case` clauses)
+        handle_errata_error(error)
 
       {:error, reason} ->
         # Other errors may be handled separately if desired
@@ -172,6 +183,38 @@ defmodule MyApp.SomeContext do
     end
   end
 end
+```
+
+The following runnable examples demonstrate the two patterns above. When
+rescuing, the exception is bound to a variable and then dispatched on using the
+custom guards (a `when` guard cannot be used directly in a `rescue` clause):
+
+```elixir
+iex> require Errata
+iex> alias MyApp.SomeContext.{MyDomainError, MyError}
+iex> try do
+...>   raise MyError, reason: :boom
+...> rescue
+...>   e in [MyDomainError] ->
+...>     {:specific, e.reason}
+...>
+...>   e ->
+...>     if Errata.is_error(e), do: {:errata, e.reason}, else: {:other, e}
+...> end
+{:errata, :boom}
+```
+
+When handling errors returned as values, the custom guards _can_ be used
+directly in the `when` clause of a `case` (or `with`, or function head):
+
+```elixir
+iex> require Errata
+iex> alias MyApp.SomeContext.MyError
+iex> case {:error, MyError.new(reason: :invalid_data)} do
+...>   {:error, e} when Errata.is_error(e) -> {:errata, e.reason}
+...>   {:error, other} -> {:other, other}
+...> end
+{:errata, :invalid_data}
 ```
 
 ## Compared to traditional approaches to error handling

--- a/lib/errata/error.ex
+++ b/lib/errata/error.ex
@@ -70,7 +70,7 @@ defmodule Errata.Error do
         require MyApp.SomeError, as: SomeError
 
         def some_function!(arg) do
-          raise SomeError reason: :helpful_tag, context: %{arbitrary: "metadata", arg: arg}
+          raise SomeError, reason: :helpful_tag, context: %{arbitrary: "metadata", arg: arg}
         end
       end
 


### PR DESCRIPTION
Fixes three documented examples that do not compile as written (found during a DX test drive).

1. **`rescue` with a `when` guard** — the "Handling Errata errors" example used `e when Errata.is_error(e) ->` inside `rescue`, which Elixir rejects (rescue clauses only allow a bare var or `var in [Module]`). Rewritten to rescue into a variable and dispatch with `cond/1`, with an admonition explaining the rule.
2. **Undefined variable** — the value-handling branch bound `error` but called `handle_errata_error(e)`.
3. **Missing comma** — `raise SomeError reason: ...` in the `Errata.Error` moduledoc.

Also adds two runnable `iex>` doctests (rescue-then-dispatch, and a `case` guard) so the corrected patterns are exercised by `doctest Errata` and cannot silently regress.

Verified: `mix test` → 4 doctests, 36 tests, 0 failures (run under Elixir 1.16.1/OTP 26).

Targeting the forthcoming 0.9.0.

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)