### PR TITLE
Validate error params instead of silently dropping unknown keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Breaking:** `new/1`, `create/1`, and `raise/2` now raise an `ArgumentError`
+  when given unrecognized param keys instead of silently ignoring them. Only
+  `:message`, `:reason`, and `:context` are accepted. Callers that previously
+  relied on extra keys being dropped will need to remove them. (#3)
+

--- a/lib/errata/errors.ex
+++ b/lib/errata/errors.ex
@@ -3,19 +3,42 @@ defmodule Errata.Errors do
 
   import Errata
 
+  # The only keys callers are allowed to set when creating an error. Internal
+  # fields (`:kind`, `:env`, `:__errata_error__`) are managed by Errata itself.
+  @allowed_param_keys [:message, :reason, :context]
+
   @doc false
   @spec create(module() | struct(), Errata.Error.params()) :: Errata.Error.t()
   def create(error_type, params) do
-    struct(error_type, params)
+    struct(error_type, validate_params!(params))
   end
 
   @doc false
   @spec create(module() | struct(), Errata.Error.params(), Macro.Env.t(), Exception.stacktrace()) ::
           Errata.error()
   def create(error_type, params, %Macro.Env{} = env, stacktrace) do
-    error = struct(error_type, params)
+    error = struct(error_type, validate_params!(params))
 
     %{error | env: Errata.Env.new(env, stacktrace)}
+  end
+
+  # Reject unknown/misspelled param keys instead of silently dropping them
+  # (which `struct/2` would do). Returns the params unchanged when valid.
+  defp validate_params!(params) do
+    invalid =
+      params
+      |> Enum.map(fn {key, _value} -> key end)
+      |> Enum.reject(&(&1 in @allowed_param_keys))
+
+    case invalid do
+      [] ->
+        params
+
+      keys ->
+        raise ArgumentError,
+              "invalid param key(s) for an Errata error: #{inspect(keys)}. " <>
+                "Allowed keys are #{inspect(@allowed_param_keys)}."
+    end
   end
 
   @doc false

--- a/test/errata/error_test.exs
+++ b/test/errata/error_test.exs
@@ -22,12 +22,10 @@ defmodule Errata.ErrorTest do
   end
 
   describe "new/1" do
-    test "uses default values" do
-      error = TestError.new(unrecognized: "ignore me")
-      assert error.message == "this is only a test"
-      assert error.reason == :testing_123
-      refute error.context
-      refute error.env
+    test "raises ArgumentError on unrecognized param keys" do
+      assert_raise ArgumentError, ~r/invalid param key\(s\).*:unrecognized/, fn ->
+        TestError.new(unrecognized: "ignore me")
+      end
     end
 
     test "overrides default reason" do
@@ -64,13 +62,10 @@ defmodule Errata.ErrorTest do
   end
 
   describe "create/1" do
-    test "uses default values" do
-      error = TestError.create(unrecognized: "ignore me")
-      assert error.message == "this is only a test"
-      assert error.reason == :testing_123
-      refute error.context
-
-      assert %{module: _, function: _, file: _, line: _} = error.env
+    test "raises ArgumentError on unrecognized param keys" do
+      assert_raise ArgumentError, ~r/invalid param key\(s\).*:unrecognized/, fn ->
+        TestError.create(unrecognized: "ignore me")
+      end
     end
 
     test "overrides default reason" do


### PR DESCRIPTION
`new/1`, `create/1`, and `raise/2` all route through `Errata.Errors.create/2`, which used `struct/2` and therefore **silently ignored unknown keys**. A misspelled `reason:`/`context:` produced a context-less error with no signal — defeating the structured-error value proposition exactly when it matters most.

This validates params against the allowed keys (`:message`, `:reason`, `:context`) and raises an `ArgumentError` naming both the offending keys and the allowed set. Internal fields (`:kind`, `:env`, `:__errata_error__`) remain off-limits to callers.

```
** (ArgumentError) invalid param key(s) for an Errata error: [:reasn]. Allowed keys are [:message, :reason, :context].
```

### ⚠️ Breaking change
Strict-by-default: callers that previously relied on extra keys being dropped will now get an `ArgumentError`. Two existing tests asserted the old lenient behavior and now assert the raise. CHANGELOG updated with the breaking-change note. Acceptable under 0.x semver; **targeting 0.9.0.**

Verified: `mix test` → 0 failures (Elixir 1.16.1/OTP 26).

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)