### PR TITLE
Add Errata.create/2 to avoid per-error-module require

### DIFF
--- a/lib/errata.ex
+++ b/lib/errata.ex
@@ -95,4 +95,38 @@ defmodule Errata do
   defguard is_infrastructure_error(term)
            when is_error(term) and
                   :erlang.map_get(:kind, term) == :infrastructure
+
+  @doc """
+  Creates an error of the given `error_module`, capturing the current `__ENV__`
+  and stacktrace into the `:env` field.
+
+  This is a convenience equivalent to the per-module `c:Errata.Error.create/1`
+  macro, but it lives on the `Errata` module. Because you typically already
+  `require Errata` (to use the guards above), you can `alias` your error modules
+  and call `Errata.create/2` for any of them without a separate `require` for
+  each error type:
+
+      defmodule MyApp.SomeContext do
+        require Errata
+        alias MyApp.SomeContext.{UnknownThing, ThingConflict}
+
+        def fetch(id) do
+          {:error, Errata.create(UnknownThing, reason: :not_found, context: %{id: id})}
+        end
+      end
+
+  Compare to the per-module macro, which requires a `require` for every error
+  type used in the module:
+
+      require MyApp.SomeContext.UnknownThing, as: UnknownThing
+      require MyApp.SomeContext.ThingConflict, as: ThingConflict
+  """
+  defmacro create(error_module, params \\ Macro.escape(%{})) do
+    quote do
+      {:current_stacktrace, [_process_info_call | stacktrace]} =
+        Process.info(self(), :current_stacktrace)
+
+      Errata.Errors.create(unquote(error_module), unquote(params), __ENV__, stacktrace)
+    end
+  end
 end

--- a/test/errata_test.exs
+++ b/test/errata_test.exs
@@ -153,4 +153,30 @@ defmodule ErrataTest do
       end
     end
   end
+
+  describe "create/2" do
+    # Note: only `require Errata`/`import Errata` is needed here (already done
+    # above) — no `require TestDomainError`. That is the point of this macro.
+    test "builds the error, sets params, and captures the current env" do
+      error = create(TestDomainError, reason: :boom, context: %{a: 1})
+
+      assert is_domain_error(error)
+      assert error.reason == :boom
+      assert error.context == %{a: 1}
+
+      assert %Errata.Env{module: module, function: _, line: line, stacktrace: stacktrace} =
+               error.env
+
+      assert module == __MODULE__
+      assert is_integer(line)
+      assert is_list(stacktrace)
+    end
+
+    test "works with no params" do
+      error = create(TestGeneralError)
+
+      assert is_error(error)
+      assert %Errata.Env{module: __MODULE__} = error.env
+    end
+  end
 end


### PR DESCRIPTION
Using the per-module `create/1` macro means every calling module must `require ErrataModule, as: ...` for **each** error type it creates — the headline feature (env + stacktrace capture) sits behind the most boilerplate, while the friction-free `new/1` silently gives up the env.

Since callers typically already `require Errata` for the guards, this adds a centralized `Errata.create/2` macro. Callers `alias` their error modules and call `Errata.create(SomeError, params)` with no per-module require. It captures `__ENV__` and the stacktrace into `:env` exactly like the per-module macro.

**Before**
```elixir
require ErrataDrive.Inventory.UnknownSku, as: UnknownSku
require ErrataDrive.Inventory.InsufficientStock, as: InsufficientStock
UnknownSku.create(reason: :unknown_sku, context: %{sku: sku})
```
**After**
```elixir
require Errata
alias ErrataDrive.Inventory.{UnknownSku, InsufficientStock}
Errata.create(UnknownSku, reason: :unknown_sku, context: %{sku: sku})
```

Purely additive / non-breaking — `MyError.create/1` still works, so both styles coexist. Tradeoff: the error type moves from the receiver to the first argument (`Errata.create(UnknownSku, …)` vs `UnknownSku.create(…)`), trading a little call-site elegance for removing the per-module require.

Verified: `mix test` → 38 tests, 0 failures (Elixir 1.16.1/OTP 26).

Targeting 0.9.0.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)