### PR TITLE
Add generic Errata.to_map/1 for any error value

### DIFF
--- a/lib/errata.ex
+++ b/lib/errata.ex
@@ -129,4 +129,32 @@ defmodule Errata do
       Errata.Errors.create(unquote(error_module), unquote(params), __ENV__, stacktrace)
     end
   end
+
+  @doc """
+  Converts any Errata error to a plain, JSON-encodable map.
+
+  This is the generic counterpart to the per-type `c:Errata.Error.to_map/1`
+  callback: it works on _any_ value for which `is_error/1` returns `true`,
+  without needing to know the error's specific module. This is convenient at
+  system boundaries (such as a Phoenix fallback controller) where errors of
+  many different types are handled uniformly.
+
+      iex> alias MyApp.SomeContext.MyError
+      iex> error = MyError.new(reason: :invalid_data, context: %{foo: "bar"})
+      iex> map = Errata.to_map(error)
+      iex> map.error_type
+      MyApp.SomeContext.MyError
+      iex> map.reason
+      :invalid_data
+      iex> map.context
+      %{foo: "bar"}
+
+  Raises an `ArgumentError` if `error` is not an Errata error.
+  """
+  @spec to_map(error()) :: map()
+  def to_map(error) when is_error(error), do: Errata.Errors.to_map(error)
+
+  def to_map(other) do
+    raise ArgumentError, "expected an Errata error, got: #{inspect(other)}"
+  end
 end

--- a/lib/errata/errors.ex
+++ b/lib/errata/errors.ex
@@ -1,7 +1,9 @@
 defmodule Errata.Errors do
   @moduledoc false
 
-  import Errata
+  # Import only the guard we use; a bare `import Errata` would also pull in
+  # `Errata.to_map/1`, which conflicts with this module's local `to_map/1`.
+  import Errata, only: [is_error: 1]
 
   # The only keys callers are allowed to set when creating an error. Internal
   # fields (`:kind`, `:env`, `:__errata_error__`) are managed by Errata itself.

--- a/test/errata_test.exs
+++ b/test/errata_test.exs
@@ -179,4 +179,27 @@ defmodule ErrataTest do
       assert %Errata.Env{module: __MODULE__} = error.env
     end
   end
+
+  describe "to_map/1" do
+    test "converts any Errata error to a map without knowing its module" do
+      error = TestDomainError.new(reason: :boom, context: %{a: 1})
+      map = Errata.to_map(error)
+
+      assert map.error_type == TestDomainError
+      assert map.reason == :boom
+      assert map.context == %{a: 1}
+      # matches the per-module callback for the same error
+      assert map == TestDomainError.to_map(error)
+    end
+
+    test "raises ArgumentError for non-Errata values" do
+      assert_raise ArgumentError, ~r/expected an Errata error/, fn ->
+        Errata.to_map(%RuntimeError{})
+      end
+
+      assert_raise ArgumentError, ~r/expected an Errata error/, fn ->
+        Errata.to_map(:not_an_error)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #5.

The per-type `to_map/1` callback requires knowing an error's concrete module, so generic boundary code (e.g. a Phoenix fallback controller) had to reach through the struct:

```elixir
error.__struct__.to_map(error)   # awkward
```

This adds `Errata.to_map/1`, which works on any value for which `is_error/1` returns true and raises `ArgumentError` otherwise:

```elixir
Errata.to_map(error)   # works for any Errata error
```

### Note
`Errata.Errors` did a bare `import Errata` (for the `is_error/1` guard), which would now collide with the new `Errata.to_map/1`. Scoped that import to `only: [is_error: 1]`.

Verified locally (Elixir 1.17.2 / OTP 27.0.1): 5 doctests, 40 tests, format, credo, and dialyzer all pass.

Part of the 0.9.0 milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)