### PR TITLE
CI/toolchain housekeeping: bump actions, fix .tool-versions pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           - elixir: "1.18.4"
             otp: "27.2"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: erlef/setup-beam@v1
         with:
@@ -48,7 +48,7 @@ jobs:
           otp-version: ${{ matrix.otp }}
 
       - name: Cache deps and build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -66,7 +66,7 @@ jobs:
     env:
       MIX_ENV: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: erlef/setup-beam@v1
         with:
@@ -74,7 +74,7 @@ jobs:
           otp-version: "27.2"
 
       - name: Cache deps and build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -96,7 +96,7 @@ jobs:
     env:
       MIX_ENV: dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: erlef/setup-beam@v1
         with:
@@ -104,7 +104,7 @@ jobs:
           otp-version: "27.2"
 
       - name: Cache deps and build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             deps
@@ -116,7 +116,7 @@ jobs:
       # The PLT only changes when the OTP/Elixir/deps change, so cache it
       # separately and keep it across runs to avoid the slow rebuild.
       - name: Cache PLT
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: priv/plts
           key: ${{ runner.os }}-plt-1.18.4-27.2-${{ hashFiles('**/mix.lock') }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.15.7-otp-26
+elixir 1.16.1-otp-26
 erlang 26.2.1


### PR DESCRIPTION
Two small follow-ups noted while setting up CI (#12).

### Bump CI actions to clear Node 20 deprecation
`actions/checkout@v4` and `actions/cache@v4` run on the deprecated Node 20 runtime (forced to Node 24 after 2026-06-16). Bumped to the current majors — **checkout v6, cache v5** — which run on Node 24.

### Pin `.tool-versions` to an installed combo
`.tool-versions` pinned `elixir 1.15.7-otp-26`, a build most contributors won't have installed, causing asdf to fall back to a mismatched Elixir/OTP pairing — the exact source of the earlier `matchstate` build failure. Pinned **`elixir 1.16.1-otp-26`** to match the already-pinned `erlang 26.2.1`. CI still exercises the full 1.15–1.18 matrix independently of this file.

Part of the 0.9.0 milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)