### PR TITLE
Clarify error kinds, type-vs-reason, and create usage in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,25 +33,43 @@ Errata errors fall into one of three general classifications:
   (as opposed to application code) or any other sort of error condition for
   which there is no need to distinguish based on classification.
 
+An error's classification—its _kind_—is primarily a concern at the boundaries
+of the system rather than within domain logic. Code at the edges of the
+application (such as a Phoenix fallback controller) can use the custom guards
+described under [Handling Errata errors](#handling-errata-errors) to decide how
+to treat an error based on its kind: domain errors might become `4xx` responses
+that are safe to show to users, while infrastructure errors become `5xx`
+responses that are logged with alerting and hidden from users. Within your
+domain logic, by contrast, you typically dispatch on the specific error _type_.
+In short: an error's **kind** decides how the boundary treats it, while its
+**type** decides how your domain logic behaves.
+
 ## Defining custom error types
 
-Errata makes it easy to define custom error types for applications or libraries.
-The following examples demonstrate how to define domain errors, infrastructure
-errors, and general errors.
+Most errors in an application are either _domain errors_ or _infrastructure
+errors_, so Errata provides a dedicated module for each. Prefer these two when
+defining custom error types: they make the classification explicit and allow
+domain and infrastructure errors to be identified throughout the system.
 
 ```elixir
 defmodule MyApp.SomeContext.MyDomainError do
-  # Define a custom domain error in some context.
+  # A business-rule violation or other error within the problem domain.
   use Errata.DomainError
 end
 
 defmodule MyApp.SomeContext.MyInfrastructureError do
-  # Define a custom infrastructure error in some context.
+  # A network timeout, database failure, or other infrastructure-level error.
   use Errata.InfrastructureError
 end
+```
 
+For the occasional error that fits neither category—such as an error
+originating in library code—use the base `Errata.Error` module, which creates
+an error of kind `:general`:
+
+```elixir
 defmodule MyApp.SomeContext.MyError do
-  # Define a custom error in some context.
+  # An error that is neither a domain nor an infrastructure error.
   use Errata.Error
 end
 ```
@@ -105,6 +123,30 @@ iex> match?(%Errata.Env{stacktrace: stacktrace} when is_list(stacktrace), error.
 true
 ```
 
+> #### Prefer `create/1` to capture context {: .tip}
+>
+> Because `new/1` leaves the `:env` field as `nil`, it discards the module,
+> function, file, line, and stacktrace of the error's origin—often the most
+> useful information when debugging or reporting an error. Prefer `create/1`
+> (or `Errata.create/2`, below) unless you have a specific reason not to
+> capture this context.
+
+The `create/1` macro requires `require/2`-ing each error module. As an
+alternative, the `Errata.create/2` macro creates an error of any type without a
+separate `require` for each one—handy when a module works with several error
+types. Since you typically already `require Errata` to use the custom guards,
+you can `alias` your error modules and call `Errata.create/2` directly:
+
+```elixir
+iex> require Errata
+iex> alias MyApp.SomeContext.MyError
+iex> error = Errata.create(MyError, reason: :invalid_data)
+iex> error.reason
+:invalid_data
+iex> match?(%Errata.Env{}, error.env)
+true
+```
+
 Whether `new/1` or `create/1` is used to create the error, it is preferable to
 wrap the error in a tuple when returning it as a value from functions:
 
@@ -112,6 +154,31 @@ wrap the error in a tuple when returning it as a value from functions:
 {:error, MyError.new(reason: :invalid_data)}
 {:error, MyError.create(reason: :invalid_data)}
 ```
+
+## Error types vs. the `:reason` field
+
+Errata errors carry both a _type_ (the module) and an optional `:reason` atom,
+and it is not always obvious which to reach for. As a rule of thumb:
+
+- Use a **distinct error type** for each condition that callers may want to
+  handle differently or that has its own meaning in the domain. The type is the
+  primary identity of an error and the thing you pattern match on.
+- Use the **`:reason`** field to _sub-classify_ within a single error type—to
+  distinguish variations of the same error that share handling but differ in
+  cause.
+
+For example, a single `PaymentDeclined` domain error can use `:reason` to record
+why the payment was declined, rather than defining a separate type for each
+cause:
+
+```elixir
+PaymentDeclined.create(reason: :insufficient_funds)
+PaymentDeclined.create(reason: :fraud_suspected)
+```
+
+Conversely, a `:reason` that merely restates the type name (such as
+`UnknownSku.create(reason: :unknown_sku)`) adds no information and can be
+omitted.
 
 ## Handling Errata errors
 
@@ -125,7 +192,11 @@ Errata provides custom guards for handling Errata error types specifically:
 - `Errata.is_domain_error/1`
 - `Errata.is_infrastructure_error/1`
 
-To use these custom guards, `import` or `require` the `Errata` module.
+To use these custom guards, `import` or `require` the `Errata` module. The
+kind-based guards (`is_domain_error/1` and `is_infrastructure_error/1`) are
+especially useful at system boundaries—for example, translating domain errors
+into client errors (`4xx`) and infrastructure errors into server errors (`5xx`)
+with alerting—while domain logic generally matches on the specific error type.
 
 The following example demonstrates handling Errata errors both as raised
 exceptions and as error values returned from functions.

--- a/lib/errata/error.ex
+++ b/lib/errata/error.ex
@@ -17,9 +17,11 @@ defmodule Errata.Error do
   `c:Errata.Error.new/1` or `c:Errata.Error.create/1` and use them as return values from
   functions, either directly or wrapped in an error tuple such as `{:error, my_error}`.
 
-  Error types defined with `Errata.Error` are of kind `:general` by default. See also
-  `Errata.DomainError` and `Errata.InfrastructureError` for defining domain errors and
-  infrastructure errors, specifically.
+  Error types defined with `Errata.Error` are of kind `:general` by default. Since most errors
+  are either domain errors or infrastructure errors, prefer `Errata.DomainError` or
+  `Errata.InfrastructureError` (which share all of the functionality described here) when
+  defining custom error types, and use `Errata.Error` directly only for general errors that fit
+  neither category, such as errors originating in library code.
 
   ## Usage
 


### PR DESCRIPTION
Closes #8 — the conceptual/docs feedback from the DX review.

### Changes (docs only)
- **Reframe kinds (point 2).** "Defining custom error types" now leads with `Errata.DomainError` and `Errata.InfrastructureError` as the two primary entry points, and presents the base `Errata.Error` (kind `:general`) as the explicit fallback for errors that fit neither category. The `Errata.Error` moduledoc is updated to match.
- **Kind = boundary concern (point 1).** New framing that an error's *kind* decides how the system boundary treats it (HTTP class, severity, alerting), while its *type* drives domain-logic dispatch.
- **`new/1` vs `create/1` (point 4).** A prominent "prefer `create/1`" note (since `new/1` leaves `:env` nil), and—filling a gap from #11—documentation of the `Errata.create/2` macro as the require-free alternative.
- **Type vs `:reason` (point 3).** New section: use a distinct error *type* per condition you match on; use `:reason` to sub-classify within a type. Notes that a reason restating the type name adds nothing.

### Verification (Elixir 1.16.1 / OTP 26)
6 doctests, 40 tests, 0 failures; `mix format`, `mix credo --strict`, and `mix docs` all clean. (The new `Errata.create/2` README example is a doctest.)

Per the discussion on #8, this takes the "reframe Domain/Infrastructure as primary" approach — docs/framing only, no code or API changes.

Part of the 0.9.0 milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)