### PR TITLE
Add error wrapping (chaining) via a :cause field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.10.0]
+
+### Added
+- Error wrapping (chaining): error types can now carry a `:cause` — the original
+  error, exception, or value that led to them — without losing the context of
+  the underlying failure.
+  - A generated `wrap/1,2` macro on each error module wraps a caught error as the
+    `:cause` of a new error, capturing the current `__ENV__` (like `create/1`)
+    and, when given `stacktrace: __STACKTRACE__`, the original error's stacktrace.
+  - `new/1`, `create/1`, and `raise/2` now also accept a `:cause` param.
+  - The cause is stored as an `Errata.Cause` struct (`kind`/`value`/`stacktrace`).
+  - `Errata.cause/1` returns the immediate cause; `Errata.root_cause/1` walks the
+    chain to the deepest cause; `Errata.format_chain/1` renders the full
+    `Caused by:` chain for logging.
+  - `to_map/1` (and JSON) now include the cause, recursing into wrapped Errata
+    errors and rendering standard exceptions by type and message.
+
 ## [0.9.0] - 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Each Errata error is an `Exception` struct with a well-defined set of fields:
   * `message` — a human-readable description of the error
   * `reason` — an atom that classifies the error, useful for pattern matching
   * `context` — a map of arbitrary metadata captured at the site of the error
+  * `cause` — the original error wrapped by this one, when it was created from a
+    lower-level failure (see `Errata.Cause` and `Errata.cause/1`)
   * `env` — the module, function, file, line, and stacktrace where the error
     was created (see `Errata.Env`)
 
@@ -33,6 +35,8 @@ With Errata you can:
     in an `{:error, error}` tuple or raised with `raise/2`.
   * **Capture rich context** — an error reason, arbitrary metadata, and the
     exact point of origin (module, function, file, line, and stacktrace).
+  * **Wrap lower-level errors** — catch an exception or error value and wrap it
+    as the `:cause` of a structured Errata error, without losing the original.
   * **Classify errors** as domain, infrastructure, or general, and branch on
     that classification at system boundaries with the `Errata` guards.
   * **Serialize errors automatically** — every error type implements the
@@ -222,6 +226,46 @@ raised with `raise/2`, passing params as the second argument:
 raise MyApp.Orders.OrderNotFound, reason: :not_found, context: %{order_id: 42}
 ```
 
+## Wrapping errors
+
+When a lower-level subsystem or external library fails, you often want to
+translate that failure into a structured Errata error of your own — without
+discarding the original. The generated `wrap/2` macro does exactly this: it
+creates an error (capturing the current `__ENV__`, like `create/1`) and stores
+the original error, exception, or value as its `:cause`.
+
+The typical use is inside a `rescue` clause, passing `__STACKTRACE__` so the
+original error's point of failure is preserved alongside it:
+
+```elixir
+iex> require MyApp.Orders.OrderNotFound, as: OrderNotFound
+iex> error =
+...>   try do
+...>     raise "the database connection dropped"
+...>   rescue
+...>     e -> OrderNotFound.wrap(e, stacktrace: __STACKTRACE__, reason: :lookup_failed)
+...>   end
+iex> error.reason
+:lookup_failed
+iex> Errata.cause(error)
+%RuntimeError{message: "the database connection dropped"}
+```
+
+The cause can be any term — another Errata error, a standard exception, or a
+plain value such as the `reason` from an `{:error, reason}` tuple. Retrieve the
+immediate cause with `Errata.cause/1`, or follow a chain of wrapped errors to
+the bottom with `Errata.root_cause/1`. The cause is also included when the error
+is serialized with `to_map/1` or encoded as JSON.
+
+For logging, `Errata.format_chain/1` renders an error together with its full
+chain of causes:
+
+```
+MyApp.Orders.OrderNotFound: the requested order does not exist: :lookup_failed
+Caused by: ** (RuntimeError) the database connection dropped
+    (stdlib 5.2) ...
+```
+
 ## Handling errors
 
 Errata errors are standard Elixir exceptions, so they can be rescued like any
@@ -401,7 +445,7 @@ Add `errata` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:errata, "~> 0.9.0"}
+    {:errata, "~> 0.10.0"}
   ]
 end
 ```

--- a/lib/errata.ex
+++ b/lib/errata.ex
@@ -26,6 +26,7 @@ defmodule Errata do
           message: String.t() | nil,
           reason: atom() | nil,
           context: map() | nil,
+          cause: Errata.Cause.t() | nil,
           env: Errata.Env.t()
         }
 
@@ -40,6 +41,7 @@ defmodule Errata do
           message: String.t() | nil,
           reason: atom() | nil,
           context: map() | nil,
+          cause: Errata.Cause.t() | nil,
           env: Errata.Env.t() | nil
         }
 
@@ -54,6 +56,7 @@ defmodule Errata do
           message: String.t() | nil,
           reason: atom() | nil,
           context: map() | nil,
+          cause: Errata.Cause.t() | nil,
           env: Errata.Env.t() | nil
         }
 
@@ -76,6 +79,7 @@ defmodule Errata do
                   is_map_key(term, :message) and
                   is_map_key(term, :reason) and
                   is_map_key(term, :context) and
+                  is_map_key(term, :cause) and
                   is_map_key(term, :env)
 
   @doc """
@@ -183,5 +187,104 @@ defmodule Errata do
 
   def display_message(other) do
     raise ArgumentError, "expected an Errata error, got: #{inspect(other)}"
+  end
+
+  @doc """
+  Returns the immediate cause wrapped by `error`, or `nil` if it has none.
+
+  The cause is the original error, exception, or value that was wrapped when the
+  error was created (typically via the generated `c:Errata.Error.wrap/2` macro,
+  or by passing a `:cause` to `c:Errata.Error.new/1` or `c:Errata.Error.create/1`).
+  This returns the bare wrapped value; the captured stacktrace (if any) is held
+  in the error's `:cause` field as an `Errata.Cause` struct.
+
+      iex> alias MyApp.Orders.OrderNotFound
+      iex> require OrderNotFound
+      iex> original = %RuntimeError{message: "boom"}
+      iex> error = OrderNotFound.wrap(original, reason: :lookup_failed)
+      iex> Errata.cause(error)
+      %RuntimeError{message: "boom"}
+
+      iex> alias MyApp.Orders.OrderNotFound
+      iex> Errata.cause(OrderNotFound.new(reason: :not_found))
+      nil
+
+  Raises an `ArgumentError` if `error` is not an Errata error.
+  """
+  @spec cause(error()) :: term() | nil
+  def cause(error) when is_error(error) do
+    case error.cause do
+      %Errata.Cause{value: value} -> value
+      nil -> nil
+    end
+  end
+
+  def cause(other) do
+    raise ArgumentError, "expected an Errata error, got: #{inspect(other)}"
+  end
+
+  @doc """
+  Walks the cause chain of `error` and returns the deepest (root) cause, or `nil`
+  if `error` has no cause.
+
+  When a wrapped cause is itself an Errata error carrying its own cause, the
+  chain is followed to the bottom.
+
+      iex> alias MyApp.Orders.{OrderNotFound, PaymentDeclined}
+      iex> require OrderNotFound
+      iex> require PaymentDeclined
+      iex> root = %RuntimeError{message: "db down"}
+      iex> inner = OrderNotFound.wrap(root, reason: :lookup_failed)
+      iex> outer = PaymentDeclined.wrap(inner, reason: :declined)
+      iex> Errata.root_cause(outer)
+      %RuntimeError{message: "db down"}
+
+  Raises an `ArgumentError` if `error` is not an Errata error.
+  """
+  @spec root_cause(error()) :: term() | nil
+  def root_cause(error) when is_error(error) do
+    case cause(error) do
+      nil -> nil
+      value -> if is_error(value), do: root_cause(value) || value, else: value
+    end
+  end
+
+  def root_cause(other) do
+    raise ArgumentError, "expected an Errata error, got: #{inspect(other)}"
+  end
+
+  @doc """
+  Renders `error` and its full cause chain as a multi-line string for logging.
+
+  The head is the error's own developer-oriented message (as returned by
+  `Exception.message/1`), followed by a `Caused by:` line for each wrapped cause.
+  Wrapped Errata errors recurse into their own chain; other wrapped values are
+  rendered via `Exception.format/3`, including the captured stacktrace when one
+  is present.
+
+  Unlike `Exception.message/1`, which is kept clean and reports only the error's
+  own message, this includes the entire chain — use it where you want the
+  underlying context surfaced, such as a log entry.
+
+  Raises an `ArgumentError` if `error` is not an Errata error.
+  """
+  @spec format_chain(error()) :: String.t()
+  def format_chain(error) when is_error(error) do
+    head = "#{inspect(error.__struct__)}: #{Exception.message(error)}"
+
+    case error.cause do
+      nil -> head
+      %Errata.Cause{} = cause -> head <> "\nCaused by: " <> format_cause(cause)
+    end
+  end
+
+  def format_chain(other) do
+    raise ArgumentError, "expected an Errata error, got: #{inspect(other)}"
+  end
+
+  defp format_cause(%Errata.Cause{value: value}) when is_error(value), do: format_chain(value)
+
+  defp format_cause(%Errata.Cause{kind: kind, value: value, stacktrace: stacktrace}) do
+    Exception.format(kind, value, stacktrace || [])
   end
 end

--- a/lib/errata/cause.ex
+++ b/lib/errata/cause.ex
@@ -1,0 +1,68 @@
+defmodule Errata.Cause do
+  @moduledoc """
+  A struct that holds the original error wrapped (chained) by an Errata error.
+
+  When an Errata error is created with a `:cause` (typically via the generated
+  `c:Errata.Error.wrap/2` macro), the original error is stored in the error's
+  `:cause` field as an `Errata.Cause` struct. This preserves the context of the
+  underlying failure without losing the benefits of a structured Errata error.
+
+  The struct has the following fields:
+
+    * `kind` - the kind of the wrapped error, one of `:error`, `:throw`, or
+      `:exit`, mirroring the first argument of `Exception.format/3`. Defaults to
+      `:error`.
+    * `value` - the wrapped error itself. This can be any term: another Errata
+      error, a standard exception struct, or an arbitrary value such as the
+      `reason` from an `{:error, reason}` tuple.
+    * `stacktrace` - the stacktrace captured at the point the original error was
+      caught (typically `__STACKTRACE__` from a `rescue`/`catch` clause), or
+      `nil` if none was provided.
+
+  Whereas the `:env` field of an Errata error records _where the error was
+  wrapped_, the `:stacktrace` of the cause records _where the original error
+  occurred_.
+
+  Use `Errata.cause/1` and `Errata.root_cause/1` to access the wrapped value(s),
+  and `Errata.format_chain/1` to render a full cause chain for logging.
+  """
+
+  @typedoc """
+  Type to represent the kind of a wrapped error.
+
+  Mirrors the kinds accepted by `Exception.format/3`.
+  """
+  @type kind :: :error | :throw | :exit
+
+  @typedoc """
+  Type to represent a wrapped (chained) error.
+  """
+  @type t :: %Errata.Cause{
+          kind: kind(),
+          value: term(),
+          stacktrace: Exception.stacktrace() | nil
+        }
+
+  defstruct kind: :error, value: nil, stacktrace: nil
+
+  @doc """
+  Normalizes a value into an `Errata.Cause` struct.
+
+  If `value` is already an `Errata.Cause`, it is returned unchanged. Otherwise a
+  new struct is built, wrapping `value`. The following options are supported:
+
+    * `:kind` - the kind of the wrapped error (see `t:kind/0`); defaults to `:error`
+    * `:stacktrace` - the stacktrace captured where the original error occurred
+  """
+  @spec new(term(), keyword()) :: t()
+  def new(value, opts \\ [])
+  def new(%__MODULE__{} = cause, _opts), do: cause
+
+  def new(value, opts) do
+    %__MODULE__{
+      kind: Keyword.get(opts, :kind, :error),
+      value: value,
+      stacktrace: Keyword.get(opts, :stacktrace)
+    }
+  end
+end

--- a/lib/errata/error.ex
+++ b/lib/errata/error.ex
@@ -98,7 +98,7 @@ defmodule Errata.Error do
 
   See also `t:params/0`.
   """
-  @type param :: :message | :reason | :context
+  @type param :: :message | :reason | :context | :cause
 
   @typedoc """
   Type to represent allowable values to be passes as params for creating error structs.
@@ -141,6 +141,47 @@ defmodule Errata.Error do
   Note that because this is a macro, callers must `require/2` the error module to be able to use it.
   """
   @macrocallback create(params()) :: Macro.t()
+
+  @doc """
+  Invoked to wrap an existing error, exception, or arbitrary value as the
+  `:cause` of a new error struct, capturing the current `__ENV__`.
+
+  This is the idiomatic way to translate a lower-level failure into a structured
+  Errata error without losing the context of the original. It is equivalent to
+  `c:create/1` with the given `cause` placed in the `:cause` field. See
+  `c:wrap/2` to also provide params (such as a `:reason`) and the original
+  stacktrace.
+
+  Like `c:create/1`, this is a macro, so callers must `require/2` the error module.
+  """
+  @macrocallback wrap(cause :: Macro.t()) :: Macro.t()
+
+  @doc """
+  Invoked to wrap an existing error as the `:cause` of a new error struct, with
+  the given `opts`, capturing the current `__ENV__`.
+
+  In addition to the standard params accepted by `c:create/1` (`:message`,
+  `:reason`, `:context`), `opts` may include:
+
+    * `:stacktrace` - the stacktrace where the original error occurred, typically
+      `__STACKTRACE__` from within a `rescue`/`catch` clause
+    * `:kind` - the kind of the wrapped error, one of `:error` (the default),
+      `:throw`, or `:exit`
+
+  The wrapped value is stored as an `Errata.Cause` in the `:cause` field, and can
+  be retrieved with `Errata.cause/1`. The typical use is to translate a rescued
+  exception while preserving its original stacktrace:
+
+      try do
+        Jason.decode!(payload)
+      rescue
+        e ->
+          {:error, MyApp.InvalidPayload.wrap(e, stacktrace: __STACKTRACE__, reason: :malformed_json)}
+      end
+
+  Like `c:create/1`, this is a macro, so callers must `require/2` the error module.
+  """
+  @macrocallback wrap(cause :: Macro.t(), opts :: Macro.t()) :: Macro.t()
 
   @doc """
   Invoked to convert an error to a plain, JSON-encodable map.

--- a/lib/errata/errors.ex
+++ b/lib/errata/errors.ex
@@ -7,22 +7,44 @@ defmodule Errata.Errors do
 
   # The only keys callers are allowed to set when creating an error. Internal
   # fields (`:kind`, `:env`, `:__errata_error__`) are managed by Errata itself.
-  @allowed_param_keys [:message, :reason, :context]
+  @allowed_param_keys [:message, :reason, :context, :cause]
 
   @doc false
   @spec create(module() | struct(), Errata.Error.params()) :: Errata.Error.t()
   def create(error_type, params) do
-    struct(error_type, validate_params!(params))
+    error_type
+    |> struct(validate_params!(params))
+    |> normalize_cause()
   end
 
   @doc false
   @spec create(module() | struct(), Errata.Error.params(), Macro.Env.t(), Exception.stacktrace()) ::
           Errata.error()
   def create(error_type, params, %Macro.Env{} = env, stacktrace) do
-    error = struct(error_type, validate_params!(params))
+    error =
+      error_type
+      |> struct(validate_params!(params))
+      |> normalize_cause()
 
     %{error | env: Errata.Env.new(env, stacktrace)}
   end
+
+  @doc false
+  @spec wrap(module(), term(), Errata.Error.params(), Macro.Env.t(), Exception.stacktrace()) ::
+          Errata.error()
+  def wrap(error_type, cause, opts, %Macro.Env{} = env, stacktrace) do
+    {cause_opts, params} = opts |> Enum.to_list() |> Keyword.split([:kind, :stacktrace])
+    params = Keyword.put(params, :cause, Errata.Cause.new(cause, cause_opts))
+
+    create(error_type, params, env, stacktrace)
+  end
+
+  # The `:cause` param may be given as a raw value (e.g. via `new(cause: ...)`);
+  # normalize it into an `Errata.Cause` struct. A `nil` cause means "no cause".
+  defp normalize_cause(%{cause: nil} = error), do: error
+  defp normalize_cause(%{cause: %Errata.Cause{}} = error), do: error
+  defp normalize_cause(%{cause: value} = error), do: %{error | cause: Errata.Cause.new(value)}
+  defp normalize_cause(error), do: error
 
   # Reject unknown/misspelled param keys instead of silently dropping them
   # (which `struct/2` would do). Returns the params unchanged when valid.
@@ -51,9 +73,26 @@ defmodule Errata.Errors do
       error_type: inspect(error_type),
       reason: error.reason,
       message: error.message,
+      cause: cause_map(error.cause),
       env: Errata.Env.to_map(error.env),
       context: context_map(error)
     }
+  end
+
+  # Render the wrapped cause for serialization. Errata errors recurse into their
+  # full structured map; standard exceptions are rendered by type and message;
+  # any other term is kept if JSON-encodable and otherwise `inspect`'d. The
+  # cause's stacktrace is intentionally omitted, mirroring `Errata.Env.to_map/1`.
+  defp cause_map(nil), do: nil
+  defp cause_map(%Errata.Cause{value: value}), do: cause_value_map(value)
+
+  defp cause_value_map(value) when is_error(value), do: to_map(value)
+
+  defp cause_value_map(%mod{} = value) when is_exception(value),
+    do: %{error_type: inspect(mod), message: Exception.message(value)}
+
+  defp cause_value_map(value) do
+    if Errata.JSON.encodable?(value), do: value, else: inspect(value)
   end
 
   @doc false
@@ -144,6 +183,7 @@ defmodule Errata.Errors do
                    message: unquote(default_message),
                    reason: unquote(default_reason),
                    context: nil,
+                   cause: nil,
                    env: nil
 
       @impl Exception
@@ -186,6 +226,36 @@ defmodule Errata.Errors do
             Process.info(self(), :current_stacktrace)
 
           Errata.Errors.create(unquote(__module__), unquote(params), __ENV__, stacktrace)
+        end
+      end
+
+      @impl Errata.Error
+      defmacro wrap(cause) do
+        __module__ = @__errata_error_module__
+
+        quote do
+          {:current_stacktrace, [_process_info_call | stacktrace]} =
+            Process.info(self(), :current_stacktrace)
+
+          Errata.Errors.wrap(unquote(__module__), unquote(cause), [], __ENV__, stacktrace)
+        end
+      end
+
+      @impl Errata.Error
+      defmacro wrap(cause, opts) do
+        __module__ = @__errata_error_module__
+
+        quote do
+          {:current_stacktrace, [_process_info_call | stacktrace]} =
+            Process.info(self(), :current_stacktrace)
+
+          Errata.Errors.wrap(
+            unquote(__module__),
+            unquote(cause),
+            unquote(opts),
+            __ENV__,
+            stacktrace
+          )
         end
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Errata.MixProject do
   use Mix.Project
 
-  @version "0.9.0"
+  @version "0.10.0"
   @source_url "https://github.com/jvoegele/errata"
 
   def project do

--- a/test/errata/error_test.exs
+++ b/test/errata/error_test.exs
@@ -87,6 +87,84 @@ defmodule Errata.ErrorTest do
     end
   end
 
+  describe "new/1 with a :cause" do
+    test "normalizes a raw cause value into an Errata.Cause" do
+      original = %RuntimeError{message: "boom"}
+      error = TestError.new(cause: original)
+
+      assert %Errata.Cause{kind: :error, value: ^original, stacktrace: nil} = error.cause
+      refute error.env
+    end
+  end
+
+  describe "wrap/1" do
+    test "wraps a value as the cause and captures the current env" do
+      original = %RuntimeError{message: "boom"}
+      error = TestError.wrap(original)
+
+      assert %Errata.Cause{kind: :error, value: ^original, stacktrace: nil} = error.cause
+      assert %Errata.Env{module: __MODULE__} = error.env
+      # default message/reason still apply
+      assert error.message == "this is only a test"
+      assert error.reason == :testing_123
+    end
+  end
+
+  describe "wrap/2" do
+    test "stores params alongside the cause and preserves the original stacktrace" do
+      {original, stacktrace} =
+        try do
+          raise "kaboom"
+        rescue
+          e -> {e, __STACKTRACE__}
+        end
+
+      error = TestError.wrap(original, reason: :wrapped, context: %{a: 1}, stacktrace: stacktrace)
+
+      assert error.reason == :wrapped
+      assert error.context == %{a: 1}
+      assert %Errata.Cause{kind: :error, value: ^original, stacktrace: ^stacktrace} = error.cause
+      assert is_list(error.cause.stacktrace)
+      assert %Errata.Env{module: __MODULE__} = error.env
+    end
+
+    test "supports a :kind for thrown/exited causes" do
+      error = TestError.wrap(:boom, kind: :throw)
+      assert %Errata.Cause{kind: :throw, value: :boom} = error.cause
+    end
+
+    test "accepts a non-exception term as the cause" do
+      error = TestError.wrap({:error, :db_timeout}, reason: :infra)
+      assert Errata.cause(error) == {:error, :db_timeout}
+    end
+
+    test "rejects unknown param keys" do
+      assert_raise ArgumentError, ~r/invalid param key\(s\).*:bogus/, fn ->
+        TestError.wrap(%RuntimeError{}, bogus: true)
+      end
+    end
+  end
+
+  describe "to_map/1 cause serialization" do
+    test "renders a wrapped standard exception by type and message" do
+      error = TestError.new(cause: %RuntimeError{message: "boom"})
+      assert TestError.to_map(error).cause == %{error_type: "RuntimeError", message: "boom"}
+    end
+
+    test "recurses into a wrapped Errata error cause" do
+      inner = TestError.new(reason: :inner)
+      map = TestError.new(cause: inner) |> TestError.to_map()
+
+      assert map.cause.error_type == inspect(TestError)
+      assert map.cause.reason == :inner
+    end
+
+    test "is nil when there is no cause" do
+      assert TestError.new().cause == nil
+      assert TestError.to_map(TestError.new()).cause == nil
+    end
+  end
+
   describe "to_map/1" do
     test "produces a JSON-compatible map" do
       error = TestError.create(context: %{foo: "bar"})

--- a/test/errata_test.exs
+++ b/test/errata_test.exs
@@ -198,6 +198,83 @@ defmodule ErrataTest do
     end
   end
 
+  describe "cause/1 and root_cause/1" do
+    require MyApp.Orders.OrderNotFound, as: OrderNotFound
+    require MyApp.Orders.PaymentDeclined, as: PaymentDeclined
+
+    test "cause/1 returns the immediate wrapped value" do
+      original = %RuntimeError{message: "boom"}
+      error = OrderNotFound.wrap(original, reason: :lookup_failed)
+
+      assert Errata.cause(error) == original
+    end
+
+    test "cause/1 returns nil when there is no cause" do
+      assert Errata.cause(OrderNotFound.new()) == nil
+    end
+
+    test "root_cause/1 walks to the deepest cause through nested Errata errors" do
+      root = %RuntimeError{message: "db down"}
+      inner = OrderNotFound.wrap(root, reason: :lookup_failed)
+      outer = PaymentDeclined.wrap(inner, reason: :declined)
+
+      assert Errata.cause(outer) == inner
+      assert Errata.root_cause(outer) == root
+    end
+
+    test "root_cause/1 returns the immediate cause when it is already the deepest" do
+      error = OrderNotFound.wrap(%RuntimeError{message: "x"}, reason: :a)
+      assert Errata.root_cause(error) == %RuntimeError{message: "x"}
+    end
+
+    test "raise ArgumentError for non-Errata values" do
+      assert_raise ArgumentError, ~r/expected an Errata error/, fn -> Errata.cause(:nope) end
+      assert_raise ArgumentError, ~r/expected an Errata error/, fn -> Errata.root_cause(:nope) end
+    end
+  end
+
+  describe "format_chain/1" do
+    require MyApp.Orders.OrderNotFound, as: OrderNotFound
+    require MyApp.Orders.PaymentDeclined, as: PaymentDeclined
+
+    test "renders only the head when there is no cause" do
+      error = OrderNotFound.new(reason: :not_found)
+
+      assert Errata.format_chain(error) ==
+               "MyApp.Orders.OrderNotFound: the requested order does not exist: :not_found"
+    end
+
+    test "renders a Caused by line for a wrapped exception" do
+      error = OrderNotFound.wrap(%RuntimeError{message: "boom"}, reason: :lookup_failed)
+      chain = Errata.format_chain(error)
+
+      assert chain =~
+               "MyApp.Orders.OrderNotFound: the requested order does not exist: :lookup_failed"
+
+      assert chain =~ "Caused by: ** (RuntimeError) boom"
+    end
+
+    test "recurses through nested Errata causes" do
+      root = %RuntimeError{message: "db down"}
+      inner = OrderNotFound.wrap(root, reason: :lookup_failed)
+      outer = PaymentDeclined.wrap(inner, reason: :declined)
+      chain = Errata.format_chain(outer)
+
+      assert chain =~ "MyApp.Orders.PaymentDeclined: the payment was declined: :declined"
+
+      assert chain =~
+               "Caused by: MyApp.Orders.OrderNotFound: the requested order does not exist: :lookup_failed"
+
+      assert chain =~ "Caused by: ** (RuntimeError) db down"
+    end
+
+    test "raises ArgumentError for non-Errata values" do
+      assert_raise ArgumentError, ~r/expected an Errata error/, fn ->
+        Errata.format_chain(:nope)
+      end
+    end
+  end
+
   describe "display_message/1" do
     test "returns the bare :message, without the reason suffix" do
       error = TestDomainError.new(message: "human readable", reason: :some_reason)


### PR DESCRIPTION
## Summary

Adds **exception wrapping / chaining** to Errata. Application code can catch a lower-level failure — an exception from a subsystem or external library, or an arbitrary error value — and translate it into a structured Errata error of its own *without discarding the original*.

This follows the **single-cause (causal chain) model** used by Java, Python, Go, Rust, and .NET, rather than the aggregation/classification model of Splode — Errata's per-error, named, structured types complement Splode rather than competing with it.

## What's included

- **New `Errata.Cause` struct** (`kind` / `value` / `stacktrace`) — the mirror of `Errata.Env`: `Env` records *where the error was wrapped*, `Cause` records *what was wrapped and where it originally occurred*.
- **Generated `wrap/1,2` macro** on every error module — equivalent to `create/1` plus a cause. Captures the wrap-site `__ENV__`, and when given `stacktrace: __STACKTRACE__`, preserves the original error's stacktrace.
- **`:cause` param** accepted by `new/1`, `create/1`, and `raise/2` (normalized into an `Errata.Cause`).
- **Accessors**: `Errata.cause/1` (immediate cause), `Errata.root_cause/1` (walks the chain to the deepest cause), `Errata.format_chain/1` (renders the full `Caused by:` chain for logging). `Exception.message/1` stays clean — the chain only surfaces via `format_chain/1`.
- **Serialization**: `to_map/1` and JSON include the cause, recursing into wrapped Errata errors and rendering standard exceptions by type and message. The raw stacktrace is omitted from JSON, consistent with `Errata.Env.to_map/1`.
- The cause may be **any term** (an Errata error, a standard exception, or a plain value such as the `reason` from an `{:error, reason}` tuple), consistent with how errors are represented on the BEAM.
- Behaviour `@macrocallback`s for `wrap`, a "Wrapping errors" README section (with a runnable doctest), CHANGELOG entry, and version bump to **0.10.0**.

## Example

```elixir
try do
  Jason.decode!(payload)
rescue
  e ->
    {:error, MyApp.InvalidPayload.wrap(e, stacktrace: __STACKTRACE__, reason: :malformed_json)}
end
```

## Verification

- `mix test` → **11 doctests, 61 tests, 0 failures** (18 new tests + a new README doctest)
- `mix format --check-formatted`, `mix credo --strict`, `mix dialyzer` → all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)