### PR TITLE
Context enrichment: put_context/3 and merge_context/2 (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Context enrichment: `Errata.put_context/3` and `Errata.merge_context/2` add to
+  an error's `:context` as it propagates, so intermediate layers can attach
+  context the creation site did not have without rebuilding the struct. (#18)
+
 ## [0.10.0] - 2026-06-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -266,6 +266,31 @@ Caused by: ** (RuntimeError) the database connection dropped
     (stdlib 5.2) ...
 ```
 
+## Enriching context as an error propagates
+
+An error's `context` is usually captured where the error is created, but a
+structured error often travels up through several layers before it reaches a
+boundary — and those intermediate layers frequently know context that the
+creation site did not: the `user_id` known in one place, the `request_id` known
+in another. `Errata.put_context/3` and `Errata.merge_context/2` let you _enrich_
+an error's context as it propagates, without rebuilding the struct by hand.
+
+This pairs naturally with returning errors as values through a `with` chain:
+each layer attaches what it knows and lets the error continue on its way.
+
+```elixir
+iex> alias MyApp.Orders.OrderNotFound
+iex> OrderNotFound.new(reason: :not_found, context: %{order_id: 42})
+...> |> Errata.put_context(:user_id, 7)
+...> |> Errata.merge_context(%{order_id: 99})
+...> |> Map.fetch!(:context)
+%{order_id: 99, user_id: 7}
+```
+
+`put_context/3` sets a single key; `merge_context/2` merges a whole map, with the
+given values winning on any key collision. Either one initializes the `context`
+map if the error did not have one yet.
+
 ## Handling errors
 
 Errata errors are standard Elixir exceptions, so they can be rescued like any

--- a/lib/errata.ex
+++ b/lib/errata.ex
@@ -190,6 +190,70 @@ defmodule Errata do
   end
 
   @doc """
+  Returns a copy of `error` with `value` stored under `key` in its `:context` map.
+
+  Context is normally set once, at the site where an error is created. But a
+  structured error often travels up through several layers before reaching a
+  boundary, and intermediate layers frequently know context that the creation
+  site did not (the `user_id` known here, the `request_id` known there). Use
+  `put_context/3` (or `merge_context/2`) to _enrich_ an error's context as it
+  propagates, without rebuilding the struct by hand.
+
+  If the error has no context yet (`nil`), it is initialized to a map. An
+  existing value under `key` is overwritten.
+
+      iex> alias MyApp.Orders.OrderNotFound
+      iex> error = OrderNotFound.new(reason: :not_found, context: %{order_id: 42})
+      iex> Errata.put_context(error, :user_id, 7).context
+      %{order_id: 42, user_id: 7}
+
+  A typical use is enriching an error as it propagates through a `with` chain:
+
+      with {:error, err} <- fetch_order(id) do
+        {:error, Errata.put_context(err, :user_id, current_user_id)}
+      end
+
+  Raises an `ArgumentError` if `error` is not an Errata error.
+  """
+  @spec put_context(error(), term(), term()) :: error()
+  def put_context(error, key, value) when is_error(error) do
+    %{error | context: Map.put(error.context || %{}, key, value)}
+  end
+
+  def put_context(other, _key, _value) do
+    raise ArgumentError, "expected an Errata error, got: #{inspect(other)}"
+  end
+
+  @doc """
+  Returns a copy of `error` with the key/value pairs from `context` merged into
+  its `:context` map.
+
+  Like `put_context/3`, but merges an entire map at once. On key collisions, the
+  values in the given `context` win (last-write-wins). If the error has no
+  context yet (`nil`), it is initialized from `context`.
+
+      iex> alias MyApp.Orders.OrderNotFound
+      iex> error = OrderNotFound.new(reason: :not_found, context: %{order_id: 42})
+      iex> Errata.merge_context(error, %{user_id: 7, order_id: 99}).context
+      %{order_id: 99, user_id: 7}
+
+  Raises an `ArgumentError` if `error` is not an Errata error, or if `context` is
+  not a map.
+  """
+  @spec merge_context(error(), map()) :: error()
+  def merge_context(error, context) when is_error(error) and is_map(context) do
+    %{error | context: Map.merge(error.context || %{}, context)}
+  end
+
+  def merge_context(error, context) when is_error(error) do
+    raise ArgumentError, "expected a map of context to merge, got: #{inspect(context)}"
+  end
+
+  def merge_context(other, _context) do
+    raise ArgumentError, "expected an Errata error, got: #{inspect(other)}"
+  end
+
+  @doc """
   Returns the immediate cause wrapped by `error`, or `nil` if it has none.
 
   The cause is the original error, exception, or value that was wrapped when the

--- a/test/errata_test.exs
+++ b/test/errata_test.exs
@@ -275,6 +275,71 @@ defmodule ErrataTest do
     end
   end
 
+  describe "put_context/3" do
+    test "adds a key to an existing context map" do
+      error = TestDomainError.new(reason: :boom, context: %{a: 1})
+      assert Errata.put_context(error, :b, 2).context == %{a: 1, b: 2}
+    end
+
+    test "overwrites an existing key" do
+      error = TestDomainError.new(context: %{a: 1})
+      assert Errata.put_context(error, :a, 2).context == %{a: 2}
+    end
+
+    test "initializes the context when it is nil" do
+      error = TestDomainError.new(reason: :boom)
+      assert error.context == nil
+      assert Errata.put_context(error, :a, 1).context == %{a: 1}
+    end
+
+    test "leaves the rest of the error unchanged" do
+      error = TestDomainError.new(reason: :boom, context: %{a: 1})
+      updated = Errata.put_context(error, :b, 2)
+
+      assert updated.reason == :boom
+      assert updated.__struct__ == TestDomainError
+      assert is_domain_error(updated)
+    end
+
+    test "raises ArgumentError for non-Errata values" do
+      assert_raise ArgumentError, ~r/expected an Errata error/, fn ->
+        Errata.put_context(:not_an_error, :a, 1)
+      end
+    end
+  end
+
+  describe "merge_context/2" do
+    test "merges a map into an existing context" do
+      error = TestDomainError.new(context: %{a: 1})
+      assert Errata.merge_context(error, %{b: 2, c: 3}).context == %{a: 1, b: 2, c: 3}
+    end
+
+    test "the given context wins on key collisions" do
+      error = TestDomainError.new(context: %{a: 1, b: 2})
+      assert Errata.merge_context(error, %{b: 99}).context == %{a: 1, b: 99}
+    end
+
+    test "initializes the context when it is nil" do
+      error = TestDomainError.new(reason: :boom)
+      assert error.context == nil
+      assert Errata.merge_context(error, %{a: 1}).context == %{a: 1}
+    end
+
+    test "raises ArgumentError for non-Errata values" do
+      assert_raise ArgumentError, ~r/expected an Errata error/, fn ->
+        Errata.merge_context(:not_an_error, %{a: 1})
+      end
+    end
+
+    test "raises ArgumentError when the context is not a map" do
+      error = TestDomainError.new()
+
+      assert_raise ArgumentError, ~r/expected a map of context/, fn ->
+        Errata.merge_context(error, a: 1)
+      end
+    end
+  end
+
   describe "display_message/1" do
     test "returns the bare :message, without the reason suffix" do
       error = TestDomainError.new(message: "human readable", reason: :some_reason)


### PR DESCRIPTION
Closes #18.

## What

Adds two helpers on the `Errata` module to **enrich an error's `:context` as it propagates**, rather than only setting context once at creation:

- `Errata.put_context/3` — set a single key (overwrites an existing key)
- `Errata.merge_context/2` — merge a whole map (given values win on collision)

Both initialize the `:context` map when the error has none yet (`nil`).

## Why

Context is normally captured where an error is created, but a structured error often travels up through several layers before reaching a boundary — and those layers frequently know context the creation site did not (the `user_id` known here, the `request_id` known there). This was the most conspicuous everyday ergonomic gap; see #18.

## Notes

- Follows the existing `Errata.*` helper convention: an `is_error/1` guard clause plus an `ArgumentError` fallback. `merge_context/2` additionally rejects a non-map context with a distinct, clear message.
- Purely additive — no struct or serialized-shape change, no semver freeze implications.
- README gains an "Enriching context as an error propagates" subsection (with a runnable doctest), placed alongside "Wrapping errors".

## Verification

- `mix test` — 14 doctests, 71 tests, 0 failures
- `mix format --check-formatted` — clean
- `mix credo --strict` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
