### PR TITLE
Declared / enumerated reasons via the :reasons option (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Context enrichment: `Errata.put_context/3` and `Errata.merge_context/2` add to
   an error's `:context` as it propagates, so intermediate layers can attach
   context the creation site did not have without rebuilding the struct. (#18)
+- Declared reasons: error types can now enumerate their valid reasons with the
+  `:reasons` option (`use Errata.DomainError, reasons: [...]`). Creating an error
+  with a reason outside the declared set raises an `ArgumentError` (a `nil` reason
+  is always allowed); a `:default_reason`, if given, must be one of the declared
+  reasons; and a `reason/0` type enumerating them is generated for the docs. (#20)
 
 ## [0.10.0] - 2026-06-02
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Each `use` accepts a few options:
 
   * `:default_message` — the `:message` to use when none is given
   * `:default_reason` — the `:reason` to use when none is given
+  * `:reasons` — an optional list of atoms enumerating the valid reasons for the
+    type (see [Choosing between an error type and a reason](#choosing-between-an-error-type-and-a-reason))
 
 Whichever module you use, the resulting error type is an exception struct that
 conforms to the `t:Errata.error/0` type, implements the `Errata.Error`
@@ -430,6 +432,25 @@ PaymentDeclined.create(reason: :fraud_suspected)
 Conversely, a `:reason` that merely restates the type name (such as
 `OrderNotFound.create(reason: :order_not_found)`) adds no information and can be
 omitted.
+
+When a type's reasons form a known, closed set, you can **declare them** with the
+`:reasons` option. Errata then rejects any reason outside the set (a `nil`,
+unspecified reason is always allowed) and generates a `reason/0` type enumerating
+them, so the valid reasons are part of the type's documented contract:
+
+```elixir
+defmodule MyApp.Orders.PaymentDeclined do
+  use Errata.DomainError,
+    reasons: [:insufficient_funds, :fraud_suspected, :card_expired]
+end
+
+PaymentDeclined.new(reason: :insufficient_funds)   # ok
+PaymentDeclined.new(reason: :mistyped)             # ** (ArgumentError) invalid reason :mistyped ...
+```
+
+This turns the guidance above from a convention into something the compiler-adjacent
+tooling and your tests can enforce. If you also set `:default_reason`, it must be one
+of the declared `:reasons`.
 
 ## Why Errata?
 

--- a/lib/errata/error.ex
+++ b/lib/errata/error.ex
@@ -48,6 +48,12 @@ defmodule Errata.Error do
 
     * `:default_reason` - the default value to use for the `:reason` field if it is not provided
     * `:default_message` - the default value to use for the `:message` field if it is not provided
+    * `:reasons` - an optional list of atoms enumerating the valid reasons for this error type.
+      When given, creating an error (via `c:new/1`, `c:create/1`, `c:wrap/2`, or `raise/2`) with a
+      `:reason` outside this set raises an `ArgumentError`. A `nil` (unspecified) reason is always
+      allowed, and a `:default_reason`, if also given, must be one of the declared `:reasons`.
+      Declaring reasons also generates a `reason/0` type enumerating them, so the valid reasons are
+      visible in the generated documentation.
     * `:kind` - the "kind" of Errata error to create, one of `:domain`, `:infrastructure`, or
       `:general` (which is the default)
 

--- a/lib/errata/errors.ex
+++ b/lib/errata/errors.ex
@@ -15,6 +15,7 @@ defmodule Errata.Errors do
     error_type
     |> struct(validate_params!(params))
     |> normalize_cause()
+    |> validate_reason!()
   end
 
   @doc false
@@ -25,6 +26,7 @@ defmodule Errata.Errors do
       error_type
       |> struct(validate_params!(params))
       |> normalize_cause()
+      |> validate_reason!()
 
     %{error | env: Errata.Env.new(env, stacktrace)}
   end
@@ -62,6 +64,29 @@ defmodule Errata.Errors do
         raise ArgumentError,
               "invalid param key(s) for an Errata error: #{inspect(keys)}. " <>
                 "Allowed keys are #{inspect(@allowed_param_keys)}."
+    end
+  end
+
+  # When an error type declares a closed set of `:reasons`, reject any non-nil
+  # reason outside that set. A `nil` (unspecified) reason is always allowed, and
+  # types that do not declare `:reasons` are unrestricted (their generated
+  # accessor returns `nil`). Returns the error unchanged when valid.
+  defp validate_reason!(%mod{reason: reason} = error) do
+    case mod.__errata_valid_reasons__() do
+      nil ->
+        error
+
+      _valid when is_nil(reason) ->
+        error
+
+      valid ->
+        if reason in valid do
+          error
+        else
+          raise ArgumentError,
+                "invalid reason #{inspect(reason)} for #{inspect(mod)}. " <>
+                  "Declared reasons are #{inspect(valid)}."
+        end
     end
   end
 
@@ -117,8 +142,12 @@ defmodule Errata.Errors do
   @doc false
   def define(kind, module_name, opts \\ [])
       when kind in [:domain, :infrastructure, :general] and is_atom(module_name) do
+    reasons = Keyword.get(opts, :reasons)
+    validate_reasons_opt!(module_name, reasons, Keyword.get(opts, :default_reason))
+
     attribute_defs = define_attributes(module_name)
     type_def = define_type(kind)
+    reasons_def = define_reasons(reasons)
     exception_def = define_exception(kind, opts)
     errata_error_impl = define_errata_error_callbacks()
     string_chars_impl = define_string_chars_impl(module_name)
@@ -127,10 +156,57 @@ defmodule Errata.Errors do
     quote do
       unquote(attribute_defs)
       unquote(type_def)
+      unquote(reasons_def)
       unquote(exception_def)
       unquote(errata_error_impl)
       unquote(string_chars_impl)
       unquote(jason_encoder_impl)
+    end
+  end
+
+  # Validate the `:reasons` option at the `use` site (compile time). When given,
+  # it must be a non-empty list of atoms, and any `:default_reason` must be one
+  # of the declared reasons.
+  defp validate_reasons_opt!(_module, nil, _default_reason), do: :ok
+
+  defp validate_reasons_opt!(module, reasons, default_reason) do
+    unless is_list(reasons) and reasons != [] and Enum.all?(reasons, &is_atom/1) do
+      raise ArgumentError,
+            ":reasons for #{inspect(module)} must be a non-empty list of atoms, " <>
+              "got: #{inspect(reasons)}"
+    end
+
+    if not is_nil(default_reason) and default_reason not in reasons do
+      raise ArgumentError,
+            ":default_reason #{inspect(default_reason)} for #{inspect(module)} is not one of " <>
+              "the declared :reasons #{inspect(reasons)}"
+    end
+
+    :ok
+  end
+
+  # Generate the per-module reasons accessor used by `validate_reason!/1`, plus a
+  # `reason` type enumerating the declared reasons. Modules without declared
+  # reasons return `nil` (unrestricted) and get no `reason` type.
+  defp define_reasons(nil) do
+    quote do
+      @doc false
+      def __errata_valid_reasons__, do: nil
+    end
+  end
+
+  defp define_reasons(reasons) when is_list(reasons) do
+    [first | rest] = reasons
+    reason_type = Enum.reduce(rest, first, fn r, acc -> quote(do: unquote(acc) | unquote(r)) end)
+
+    quote do
+      @typedoc """
+      The set of reasons declared as valid for this error type.
+      """
+      @type reason :: unquote(reason_type)
+
+      @doc false
+      def __errata_valid_reasons__, do: unquote(reasons)
     end
   end
 

--- a/test/errata/error_test.exs
+++ b/test/errata/error_test.exs
@@ -4,6 +4,14 @@ defmodule TestError do
     default_reason: :testing_123
 end
 
+defmodule ReasonedError do
+  use Errata.DomainError, reasons: [:alpha, :beta, :gamma]
+end
+
+defmodule DefaultReasonedError do
+  use Errata.DomainError, default_reason: :alpha, reasons: [:alpha, :beta]
+end
+
 defmodule Errata.ErrorTest do
   @moduledoc "Tests for the Errata.Error module"
 
@@ -212,6 +220,72 @@ defmodule Errata.ErrorTest do
     test "exception message omits reason when it is nil" do
       assert_raise TestError, "this is only a test", fn ->
         raise TestError, reason: nil, context: %{foo: "bar"}
+      end
+    end
+  end
+
+  describe "declared :reasons" do
+    require ReasonedError
+
+    test "accepts a declared reason" do
+      assert ReasonedError.new(reason: :beta).reason == :beta
+      assert ReasonedError.create(reason: :gamma).reason == :gamma
+    end
+
+    test "allows a nil (unspecified) reason" do
+      assert ReasonedError.new().reason == nil
+      assert ReasonedError.new(reason: nil).reason == nil
+    end
+
+    test "rejects an undeclared reason from new/1" do
+      assert_raise ArgumentError, ~r/invalid reason :delta.*Declared reasons are/, fn ->
+        ReasonedError.new(reason: :delta)
+      end
+    end
+
+    test "rejects an undeclared reason from create/1" do
+      assert_raise ArgumentError, ~r/invalid reason :delta/, fn ->
+        ReasonedError.create(reason: :delta)
+      end
+    end
+
+    test "rejects an undeclared reason from wrap/2" do
+      assert_raise ArgumentError, ~r/invalid reason :delta/, fn ->
+        ReasonedError.wrap(%RuntimeError{}, reason: :delta)
+      end
+    end
+
+    test "rejects an undeclared reason from raise/2" do
+      assert_raise ArgumentError, ~r/invalid reason :delta/, fn ->
+        raise ReasonedError, reason: :delta
+      end
+    end
+
+    test "a declared :default_reason is applied and is valid by construction" do
+      assert DefaultReasonedError.new().reason == :alpha
+    end
+
+    test "types without declared reasons remain unrestricted" do
+      assert TestError.new(reason: :anything_at_all).reason == :anything_at_all
+    end
+
+    test "rejects a non-atom-list :reasons at compile time" do
+      assert_raise ArgumentError, ~r/must be a non-empty list of atoms/, fn ->
+        Code.compile_string("""
+        defmodule Errata.ErrorTest.BadReasons do
+          use Errata.DomainError, reasons: [:a, "b"]
+        end
+        """)
+      end
+    end
+
+    test "rejects a :default_reason not among :reasons at compile time" do
+      assert_raise ArgumentError, ~r/default_reason :nope.*is not one of the declared/, fn ->
+        Code.compile_string("""
+        defmodule Errata.ErrorTest.BadDefault do
+          use Errata.DomainError, default_reason: :nope, reasons: [:a, :b]
+        end
+        """)
       end
     end
   end


### PR DESCRIPTION
Closes #20.

## What

Error types can now **declare their set of valid reasons**:

```elixir
defmodule MyApp.Orders.PaymentDeclined do
  use Errata.DomainError,
    reasons: [:insufficient_funds, :fraud_suspected, :card_expired]
end
```

When declared, creating an error (`new/1`, `create/1`, `wrap/2`, or `raise/2`) with a `:reason` outside the set raises an `ArgumentError`. The feature is **opt-in**: types without `:reasons` stay unrestricted, so this is fully backward-compatible.

## Design decision

A **`nil` (unspecified) reason is always allowed** — declaring reasons does *not* make a reason mandatory. This was an explicit call (allow-nil over require-a-reason): it's the conservative, composable default and can be tightened later without breaking the model. `:default_reason`, if set, still fills `nil`.

## Implementation notes

- Each generated module exposes an internal `__errata_valid_reasons__/0` (the declared list, or `nil` when unrestricted). Validation happens at the **single `Errata.Errors.create` choke point**, so every creation path is covered by one check — no per-path duplication.
- The `:reasons` option is validated at the **`use` site (compile time)**: it must be a non-empty list of atoms, and a `:default_reason`, if given, must be one of the declared reasons.
- Declaring reasons also generates a `reason/0` type enumerating them, so the valid reasons appear in the generated docs.

## Semver

Additive and opt-in — no struct or serialized-shape change.

## Verification

- `mix test` — 14 doctests, 81 tests, 0 failures (adds runtime validation across all 4 creation paths + 2 compile-time checks)
- `mix format --check-formatted` — clean
- `mix credo --strict` — no issues
- `mix dialyzer` — 0 errors (generated `reason/0` type is well-formed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
