### PR TITLE
Error reporting: Errata.log/2 and Errata.report/2 (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   with a reason outside the declared set raises an `ArgumentError` (a `nil` reason
   is always allowed); a `:default_reason`, if given, must be one of the declared
   reasons; and a `reason/0` type enumerating them is generated for the docs. (#20)
+- Error reporting: `Errata.log/2` logs an error at a given level with its
+  `reason`, `kind`, `context`, and origin attached as structured Logger metadata;
+  `Errata.report/2` emits a `[:errata, :error]` telemetry event (and optionally
+  logs), providing a vendor-neutral seam for forwarding errors to Sentry, metrics,
+  etc. via a telemetry handler in your application. Adds a `telemetry ~> 1.0`
+  dependency. (#19)
 
 ## [0.10.0] - 2026-06-02
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ With Errata you can:
     that classification at system boundaries with the `Errata` guards.
   * **Serialize errors automatically** — every error type implements the
     `String.Chars` and `Jason.Encoder` protocols.
+  * **Report errors at a boundary** — log an error with its fields as structured
+    metadata, or emit a telemetry event for your own handler to forward to
+    Sentry, a metrics backend, or wherever errors should go.
 
 ## Quick start
 
@@ -407,6 +410,51 @@ example, `"the requested order does not exist: :not_found"`) — useful in logs
 and raised-exception output. When rendering an error for an end user, use
 `Errata.display_message/1` instead, which returns just the human-readable
 `:message`.
+
+## Reporting errors
+
+Because an Errata error carries its full context, it is straightforward to get
+it into your observability stack at a boundary. Errata provides two thin,
+composable functions for this, and — deliberately — no integration with any
+particular external service.
+
+`Errata.log/2` logs an error's developer message at the given level (`:error` by
+default), attaching its `reason`, `kind`, `context`, and origin `env` as **Logger
+metadata** rather than flattening them into the message string, so they stay
+queryable in structured logging backends:
+
+```elixir
+Errata.log(error)            # logs at :error
+Errata.log(error, :warning)  # at a chosen level
+```
+
+`Errata.report/2` emits a [`:telemetry`](https://hexdocs.pm/telemetry) event for
+the error (and, optionally, logs it). This is the seam for external reporting:
+rather than Errata depending on Sentry (or any other service), your application
+attaches a telemetry handler that forwards the error wherever it needs to go.
+The vendor integration lives in your application; Errata stays out of it.
+
+```elixir
+Errata.report(error)
+Errata.report(error, metadata: %{request_id: request_id}, log: :warning)
+```
+
+The event is `[:errata, :error]`, with measurements `%{system_time: _, count: 1}`
+(so [`Telemetry.Metrics`](https://hexdocs.pm/telemetry_metrics) counters work out
+of the box) and metadata carrying the full `:error` struct plus `:kind`,
+`:reason`, `:error_type`, and `:context` as top-level keys — simple values that
+work directly as metric tags. A handler in your application wires it up:
+
+```elixir
+:telemetry.attach("myapp-errata", [:errata, :error], &MyApp.ErrorReporter.handle/4, nil)
+
+def handle([:errata, :error], _measurements, metadata, _config) do
+  Sentry.capture_message(Exception.message(metadata.error),
+    extra: Errata.to_map(metadata.error),
+    tags: %{error_type: inspect(metadata.error_type), reason: metadata.reason}
+  )
+end
+```
 
 ## Choosing between an error type and a reason
 

--- a/lib/errata.ex
+++ b/lib/errata.ex
@@ -7,6 +7,8 @@ defmodule Errata do
              |> String.split("<!-- README END -->")
              |> List.first()
 
+  require Logger
+
   @typedoc """
   Type to represent the various kinds of Errata errors.
   """
@@ -351,4 +353,124 @@ defmodule Errata do
   defp format_cause(%Errata.Cause{kind: kind, value: value, stacktrace: stacktrace}) do
     Exception.format(kind, value, stacktrace || [])
   end
+
+  @doc """
+  Logs `error` at the given `level` (default `:error`) with its structured fields
+  attached as Logger metadata.
+
+  The log _message_ is the developer-oriented `Exception.message/1` (combining
+  `:message` and `:reason`). The error's `:reason`, `:kind`, `:context`, and
+  origin `:env` are attached as **Logger metadata** rather than being flattened
+  into the message string, so they remain queryable structured fields in
+  backends that support them. The following metadata keys are set:
+
+    * `:error_type` — the error's module
+    * `:kind` — the error's kind (`:domain` / `:infrastructure` / `:general`)
+    * `:reason` — the error's reason
+    * `:context` — the error's context map
+    * `:env` — a map of the origin `module`, `function`, `file`, and `line`
+
+  Returns `:ok`. Raises an `ArgumentError` if `error` is not an Errata error.
+  """
+  @spec log(error(), Logger.level()) :: :ok
+  def log(error, level \\ :error)
+
+  def log(error, level) when is_error(error) do
+    Logger.log(level, fn -> Exception.message(error) end, log_metadata(error))
+  end
+
+  def log(other, _level) do
+    raise ArgumentError, "expected an Errata error, got: #{inspect(other)}"
+  end
+
+  @doc """
+  Emits a `:telemetry` event for `error`, and optionally logs it.
+
+  This is the seam for error _reporting_: rather than integrating with any
+  particular external service, Errata emits a telemetry event that your
+  application handles — attaching a handler that forwards to Sentry, a metrics
+  backend, or wherever errors should go. The vendor integration stays in your
+  application; Errata stays out of it.
+
+  The event is `[:errata, :error]`, with:
+
+    * measurements `%{system_time: integer(), count: 1}` — `:count` is always `1`,
+      so `Telemetry.Metrics.counter/2` works out of the box
+    * metadata containing the full `:error` struct plus `:kind`, `:reason`,
+      `:error_type`, and `:context` as top-level keys (simple values suitable for
+      use as metric tags)
+
+  Options:
+
+    * `:metadata` — a map or keyword list of extra metadata merged into the event.
+      The standard keys above are protected: on a key collision, the standard
+      value wins.
+    * `:measurements` — extra measurements merged into the event, with the
+      standard measurements likewise protected.
+    * `:log` — also log the error via `log/2`. `false` (the default) emits
+      telemetry only; `true` logs at `:error`; an atom level (e.g. `:warning`)
+      logs at that level.
+
+  Returns `:ok`. Raises an `ArgumentError` if `error` is not an Errata error.
+
+      :telemetry.attach("myapp-errata", [:errata, :error], &MyApp.ErrorReporter.handle/4, nil)
+
+      Errata.report(error, metadata: %{request_id: request_id}, log: :warning)
+  """
+  @spec report(error(), keyword()) :: :ok
+  def report(error, opts \\ [])
+
+  def report(error, opts) when is_error(error) and is_list(opts) do
+    measurements =
+      opts
+      |> Keyword.get(:measurements, [])
+      |> Map.new()
+      |> Map.merge(%{system_time: System.system_time(), count: 1})
+
+    metadata =
+      opts
+      |> Keyword.get(:metadata, [])
+      |> Map.new()
+      |> Map.merge(standard_metadata(error))
+
+    :telemetry.execute([:errata, :error], measurements, metadata)
+
+    maybe_log(error, Keyword.get(opts, :log, false))
+
+    :ok
+  end
+
+  def report(other, _opts) do
+    raise ArgumentError, "expected an Errata error, got: #{inspect(other)}"
+  end
+
+  defp standard_metadata(error) do
+    %{
+      error: error,
+      kind: error.kind,
+      reason: error.reason,
+      error_type: error.__struct__,
+      context: error.context || %{}
+    }
+  end
+
+  defp log_metadata(error) do
+    [
+      error_type: error.__struct__,
+      kind: error.kind,
+      reason: error.reason,
+      context: error.context || %{},
+      env: env_metadata(error.env)
+    ]
+  end
+
+  defp env_metadata(%Errata.Env{module: module, function: function, file: file, line: line}) do
+    %{module: module, function: function, file: file, line: line}
+  end
+
+  defp env_metadata(_), do: %{}
+
+  defp maybe_log(_error, level) when level in [false, nil], do: :ok
+  defp maybe_log(error, true), do: log(error, :error)
+  defp maybe_log(error, level) when is_atom(level), do: log(error, level)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -45,6 +45,7 @@ defmodule Errata.MixProject do
   defp deps do
     [
       {:jason, ">= 1.3.0"},
+      {:telemetry, "~> 1.0"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.31", only: :dev, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -11,4 +11,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.16.1", "cc9e3ca312f1cfeccc572b37a09980287e243648108384b97ff2b76e505c3555", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "e127a341ad1b209bd80f7bd1620a15693a9908ed780c3b763bccf7d200c767c6"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.3", "d684f4bac8690e70b06eb52dad65d26de2eefa44cd19d64a8095e1417df7c8fd", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "b78dc853d2e670ff6390b605d807263bf606da3c82be37f9d7f68635bd886fc9"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.0", "51f9b613ea62cfa97b25ccc2c1b4216e81df970acd8e16e8d1bdc58fef21370d", [:mix], [], "hexpm", "9c565862810fb383e9838c1dd2d7d2c437b3d13b267414ba6af33e50d2d1cf28"},
+  "telemetry": {:hex, :telemetry, "1.4.2", "a0cb522801dffb1c49fe6e30561badffc7b6d0e180db1300df759faa22062855", [:rebar3], [], "hexpm", "928f6495066506077862c0d1646609eed891a4326bee3126ba54b60af61febb1"},
 }

--- a/test/errata_test.exs
+++ b/test/errata_test.exs
@@ -8,12 +8,26 @@ defmodule MyApp.Orders.PaymentDeclined do
   use Errata.DomainError, default_message: "the payment was declined"
 end
 
+# A minimal :logger handler that forwards received log events to a test process,
+# so `Errata.log/2`'s structured metadata can be asserted directly.
+defmodule ErrataTest.LogHandler do
+  @moduledoc false
+  def log(event, %{config: %{pid: pid}}), do: send(pid, {:log_event, event})
+end
+
 defmodule ErrataTest do
   use ExUnit.Case
 
   import Errata
+  import ExUnit.CaptureLog
 
   doctest Errata
+
+  # Telemetry handler used by the report/2 tests; an MFA capture avoids the
+  # local-function performance warning telemetry emits for anonymous handlers.
+  def handle_telemetry(event, measurements, metadata, %{pid: pid}) do
+    send(pid, {:telemetry_event, event, measurements, metadata})
+  end
 
   defmodule TestGeneralError do
     use Errata.Error
@@ -337,6 +351,118 @@ defmodule ErrataTest do
       assert_raise ArgumentError, ~r/expected a map of context/, fn ->
         Errata.merge_context(error, a: 1)
       end
+    end
+  end
+
+  describe "report/2" do
+    setup do
+      ref = make_ref()
+      handler_id = {__MODULE__, ref}
+
+      :telemetry.attach(
+        handler_id,
+        [:errata, :error],
+        &__MODULE__.handle_telemetry/4,
+        %{pid: self()}
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+      :ok
+    end
+
+    test "emits a telemetry event with standard measurements and metadata" do
+      error = TestDomainError.new(reason: :boom, context: %{a: 1})
+      assert Errata.report(error) == :ok
+
+      assert_received {:telemetry_event, [:errata, :error], measurements, metadata}
+      assert %{count: 1, system_time: system_time} = measurements
+      assert is_integer(system_time)
+      assert metadata.error == error
+      assert metadata.kind == :domain
+      assert metadata.reason == :boom
+      assert metadata.error_type == TestDomainError
+      assert metadata.context == %{a: 1}
+    end
+
+    test "merges caller metadata under the protected standard keys" do
+      error = TestDomainError.new(reason: :boom)
+      Errata.report(error, metadata: %{request_id: "abc", reason: :hijack})
+
+      assert_received {:telemetry_event, _event, _measurements, metadata}
+      assert metadata.request_id == "abc"
+      # the standard key wins on collision
+      assert metadata.reason == :boom
+    end
+
+    test "merges caller measurements under the protected standard keys" do
+      error = TestDomainError.new()
+      Errata.report(error, measurements: %{duration: 5, count: 99})
+
+      assert_received {:telemetry_event, _event, measurements, _metadata}
+      assert measurements.duration == 5
+      # the standard measurement wins on collision
+      assert measurements.count == 1
+    end
+
+    test "normalizes a nil context to an empty map" do
+      Errata.report(TestDomainError.new(reason: :boom))
+      assert_received {:telemetry_event, _event, _measurements, %{context: %{}}}
+    end
+
+    test "does not log by default" do
+      assert capture_log(fn -> Errata.report(TestDomainError.new(reason: :boom)) end) == ""
+    end
+
+    test "also logs when :log is set" do
+      error = TestDomainError.new(message: "boom happened", reason: :boom)
+      log = capture_log(fn -> Errata.report(error, log: :warning) end)
+      assert log =~ "boom happened"
+      assert log =~ "[warning]"
+    end
+
+    test "raises ArgumentError for non-Errata values" do
+      assert_raise ArgumentError, ~r/expected an Errata error/, fn -> Errata.report(:nope) end
+    end
+  end
+
+  describe "log/2" do
+    setup do
+      :logger.add_handler(:errata_test_log, ErrataTest.LogHandler, %{
+        config: %{pid: self()},
+        level: :all
+      })
+
+      on_exit(fn -> :logger.remove_handler(:errata_test_log) end)
+      :ok
+    end
+
+    test "logs the developer message at the given level" do
+      error = TestDomainError.new(message: "human msg", reason: :boom)
+      log = capture_log(fn -> Errata.log(error, :warning) end)
+      assert log =~ "human msg: :boom"
+      assert log =~ "[warning]"
+    end
+
+    test "attaches structured fields as Logger metadata, including the origin env" do
+      error = create(TestDomainError, message: "m", reason: :boom, context: %{a: 1})
+      capture_log(fn -> assert Errata.log(error, :warning) == :ok end)
+
+      assert_received {:log_event, event}
+      assert event.level == :warning
+      assert event.meta.error_type == TestDomainError
+      assert event.meta.kind == :domain
+      assert event.meta.reason == :boom
+      assert event.meta.context == %{a: 1}
+      assert %{module: ErrataTest, file: _, line: _} = event.meta.env
+    end
+
+    test "defaults to the :error level" do
+      capture_log(fn -> assert Errata.log(TestDomainError.new(reason: :boom)) == :ok end)
+      assert_received {:log_event, %{level: :error}}
+    end
+
+    test "raises ArgumentError for non-Errata values" do
+      assert_raise ArgumentError, ~r/expected an Errata error/, fn -> Errata.log(:nope) end
     end
   end
 


### PR DESCRIPTION
Closes #19.

Implements the telemetry event contract settled on the issue (see the [contract draft](https://github.com/jvoegele/errata/issues/19#issuecomment-4612160332) and [resolved decisions](https://github.com/jvoegele/errata/issues/19#issuecomment-4612260159)).

## What

Two thin, composable, **vendor-neutral** functions for reporting an error at a boundary:

- **`Errata.log/2`** — logs the developer message at a given level (default `:error`), attaching `:reason`, `:kind`, `:context`, and origin `:env` as **Logger metadata** (queryable structured fields, not mashed into the message).
- **`Errata.report/2`** — emits a `[:errata, :error]` telemetry event and optionally logs. The app attaches a handler that forwards to Sentry/metrics/etc.; the library takes on no vendor integration.

Event contract (now frozen for 1.0):
- measurements `%{system_time: integer(), count: 1}`
- metadata `%{error:, kind:, reason:, error_type:, context:}` — flat scalars usable as metric tags, plus the full struct.

## Resolved decisions honored

- `:log` defaults to **`false`** (telemetry-only; composable).
- Standard metadata **and** measurement keys are **protected** — caller-supplied `:metadata`/`:measurements` merge *underneath* (standard wins on collision).
- `:telemetry` is a **hard dep (`~> 1.0`)**.
- Nothing reserved for severity/retryable.

## Two implementation calls worth a look in review

1. **`log/2` default level is a flat `:error`**, matching the contract sketch (`level \\ :error`), rather than a kind-derived mapping. Decision #4 noted the default should be "derivable (from kind, or `:error`)" — I went with the simplest, least-opinionated end of that so we don't freeze a contentious kind→level table (e.g. "are domain errors warnings?") into 1.0. Kind-derived defaults remain a clean, non-breaking future enhancement. Easy to change if you'd prefer kind-derived now.
2. **Logger metadata nests `:env` and `:context` under single keys** rather than flattening every field to the top level. This is deliberate: Logger auto-populates `:module`/`:function`/`:file`/`:line` for the *log call site*, so flattening the origin env to those keys would collide. Nesting avoids the collision and still serializes as queryable nested fields in structured backends. The flat scalar tags (`error_type`, `kind`, `reason`) stay top-level.

## Semver

Additive API; the telemetry event name/measurements/metadata are the frozen public contract per the issue. Adds the `telemetry` dependency.

## Verification

- `mix test` — 14 doctests, 92 tests, 0 failures
- `mix format --check-formatted` — clean
- `mix credo --strict` — no issues
- `mix dialyzer` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
