### PR TITLE
HTTP status mapping via http_status/1 (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   logs), providing a vendor-neutral seam for forwarding errors to Sentry, metrics,
   etc. via a telemetry handler in your application. Adds a `telemetry ~> 1.0`
   dependency. (#19)
+- HTTP status mapping: each error type now has a generated, overridable
+  `http_status/1` function (and a matching `Errata.http_status/1`) that defaults
+  off the error's kind (`:domain` → `422`, `:infrastructure` → `503`, `:general`
+  → `500`). Set a specific status with the `:http_status` option, or override the
+  function to compute one from the error. No web-framework dependency is added. (#21)
 
 ## [0.10.0] - 2026-06-02
 

--- a/README.md
+++ b/README.md
@@ -402,6 +402,36 @@ iex> case {:error, OrderNotFound.new(reason: :not_found)} do
 {:errata, :not_found}
 ```
 
+### Mapping errors to HTTP status codes
+
+At an HTTP boundary you often want to translate an error into a response status.
+Every Errata error has a generated `http_status/1` function whose default is
+derived from the error's kind — `:domain` errors map to `422`, `:infrastructure`
+errors to `503`, and `:general` errors to `500`. Set a specific status per type
+with the `:http_status` option, or override `http_status/1` to compute one from
+the error's `reason` or `context`:
+
+```elixir
+defmodule MyApp.Orders.OrderNotFound do
+  use Errata.DomainError, http_status: 404
+end
+```
+
+`Errata.http_status/1` returns the status for _any_ Errata error without needing
+to know its specific type, which is convenient in a Phoenix fallback controller:
+
+```elixir
+def call(conn, {:error, error}) when Errata.is_error(error) do
+  conn
+  |> put_status(Errata.http_status(error))
+  |> put_view(MyApp.ErrorView)
+  |> render("error.json", error: error)
+end
+```
+
+This keeps Errata free of any web-framework dependency: it hands you the status
+code, and the framework glue stays in your application.
+
 ### Rendering an error for users
 
 `Exception.message/1` (and the `String.Chars` implementation) return a

--- a/lib/errata.ex
+++ b/lib/errata.ex
@@ -355,6 +355,37 @@ defmodule Errata do
   end
 
   @doc """
+  Returns the HTTP status code associated with `error`.
+
+  This delegates to the error module's generated `http_status/1` function, which
+  defaults off the error's kind — `:domain` errors map to `422`, `:infrastructure`
+  errors to `503`, and `:general` errors to `500`. A specific status can be set
+  per type with the `:http_status` option to `use Errata.Error` (and friends), or
+  by overriding `http_status/1` to compute a status from the error's `:reason` or
+  `:context`.
+
+  This lets a boundary — such as a Phoenix fallback controller — map any Errata
+  error to a response status without knowing its specific type:
+
+      def call(conn, {:error, error}) when Errata.is_error(error) do
+        conn
+        |> put_status(Errata.http_status(error))
+        |> put_view(MyApp.ErrorView)
+        |> render("error.json", error: error)
+      end
+
+  Raises an `ArgumentError` if `error` is not an Errata error.
+  """
+  @spec http_status(error()) :: non_neg_integer()
+  def http_status(error) when is_error(error) do
+    error.__struct__.http_status(error)
+  end
+
+  def http_status(other) do
+    raise ArgumentError, "expected an Errata error, got: #{inspect(other)}"
+  end
+
+  @doc """
   Logs `error` at the given `level` (default `:error`) with its structured fields
   attached as Logger metadata.
 

--- a/lib/errata/error.ex
+++ b/lib/errata/error.ex
@@ -54,6 +54,11 @@ defmodule Errata.Error do
       allowed, and a `:default_reason`, if also given, must be one of the declared `:reasons`.
       Declaring reasons also generates a `reason/0` type enumerating them, so the valid reasons are
       visible in the generated documentation.
+    * `:http_status` - the HTTP status code to associate with this error type, returned by the
+      generated `http_status/1` function (and `Errata.http_status/1`). When omitted, the status
+      defaults off the error's kind (`:domain` → `422`, `:infrastructure` → `503`, `:general` →
+      `500`). The generated `http_status/1` is overridable, so it can instead be defined to compute
+      a status from the error's `:reason` or `:context`.
     * `:kind` - the "kind" of Errata error to create, one of `:domain`, `:infrastructure`, or
       `:general` (which is the default)
 

--- a/lib/errata/errors.ex
+++ b/lib/errata/errors.ex
@@ -148,6 +148,7 @@ defmodule Errata.Errors do
     attribute_defs = define_attributes(module_name)
     type_def = define_type(kind)
     reasons_def = define_reasons(reasons)
+    http_status_def = define_http_status(kind, module_name, opts)
     exception_def = define_exception(kind, opts)
     errata_error_impl = define_errata_error_callbacks()
     string_chars_impl = define_string_chars_impl(module_name)
@@ -157,12 +158,58 @@ defmodule Errata.Errors do
       unquote(attribute_defs)
       unquote(type_def)
       unquote(reasons_def)
+      unquote(http_status_def)
       unquote(exception_def)
       unquote(errata_error_impl)
       unquote(string_chars_impl)
       unquote(jason_encoder_impl)
     end
   end
+
+  # Generate the overridable `http_status/1` function. It defaults off the error's
+  # kind (or the `:http_status` option) and is marked `defoverridable` so callers
+  # can override it to compute a status from the error's `:reason` or `:context`.
+  # It is intentionally a plain function rather than a behaviour callback, so that
+  # user overrides do not trip Elixir's `@impl` consistency warnings.
+  defp define_http_status(kind, module_name, opts) do
+    status = http_status_value!(kind, module_name, opts)
+
+    doc = """
+    Returns the HTTP status code associated with this error (`#{status}` by default).
+
+    The default is derived from the error's kind, or set via the `:http_status`
+    option. Override this function to compute a status from the error's `:reason`
+    or `:context`. See also `Errata.http_status/1`.
+    """
+
+    quote do
+      @doc unquote(doc)
+      @spec http_status(Errata.error()) :: non_neg_integer()
+      def http_status(error)
+      def http_status(_error), do: unquote(status)
+
+      defoverridable http_status: 1
+    end
+  end
+
+  defp http_status_value!(kind, module_name, opts) do
+    case Keyword.get(opts, :http_status) do
+      nil ->
+        default_http_status(kind)
+
+      status when is_integer(status) and status in 100..599 ->
+        status
+
+      other ->
+        raise ArgumentError,
+              ":http_status for #{inspect(module_name)} must be an integer HTTP status code " <>
+                "(100..599), got: #{inspect(other)}"
+    end
+  end
+
+  defp default_http_status(:domain), do: 422
+  defp default_http_status(:infrastructure), do: 503
+  defp default_http_status(:general), do: 500
 
   # Validate the `:reasons` option at the `use` site (compile time). When given,
   # it must be a non-empty list of atoms, and any `:default_reason` must be one

--- a/test/errata/error_test.exs
+++ b/test/errata/error_test.exs
@@ -12,6 +12,17 @@ defmodule DefaultReasonedError do
   use Errata.DomainError, default_reason: :alpha, reasons: [:alpha, :beta]
 end
 
+defmodule StatusOverrideError do
+  use Errata.DomainError, http_status: 404
+end
+
+defmodule DynamicStatusError do
+  use Errata.DomainError, reasons: [:missing, :conflict]
+  def http_status(%{reason: :missing}), do: 404
+  def http_status(%{reason: :conflict}), do: 409
+  def http_status(_error), do: 422
+end
+
 defmodule Errata.ErrorTest do
   @moduledoc "Tests for the Errata.Error module"
 
@@ -284,6 +295,35 @@ defmodule Errata.ErrorTest do
         Code.compile_string("""
         defmodule Errata.ErrorTest.BadDefault do
           use Errata.DomainError, default_reason: :nope, reasons: [:a, :b]
+        end
+        """)
+      end
+    end
+  end
+
+  describe "http_status/1" do
+    test "defaults off the error kind" do
+      # TestError is a :general error
+      assert TestError.http_status(TestError.new()) == 500
+      # ReasonedError is a :domain error
+      assert ReasonedError.http_status(ReasonedError.new()) == 422
+    end
+
+    test "the :http_status option overrides the kind default" do
+      assert StatusOverrideError.http_status(StatusOverrideError.new()) == 404
+    end
+
+    test "can be overridden to compute a status from the error" do
+      assert DynamicStatusError.http_status(DynamicStatusError.new(reason: :missing)) == 404
+      assert DynamicStatusError.http_status(DynamicStatusError.new(reason: :conflict)) == 409
+      assert DynamicStatusError.http_status(DynamicStatusError.new()) == 422
+    end
+
+    test "rejects an out-of-range :http_status at compile time" do
+      assert_raise ArgumentError, ~r/must be an integer HTTP status code/, fn ->
+        Code.compile_string("""
+        defmodule Errata.ErrorTest.BadStatus do
+          use Errata.DomainError, http_status: 999_999
         end
         """)
       end

--- a/test/errata_test.exs
+++ b/test/errata_test.exs
@@ -354,6 +354,18 @@ defmodule ErrataTest do
     end
   end
 
+  describe "http_status/1" do
+    test "delegates to the per-module status, defaulting off kind" do
+      assert Errata.http_status(TestDomainError.new()) == 422
+      assert Errata.http_status(TestInfrastructureError.new()) == 503
+      assert Errata.http_status(TestGeneralError.new()) == 500
+    end
+
+    test "raises ArgumentError for non-Errata values" do
+      assert_raise ArgumentError, ~r/expected an Errata error/, fn -> Errata.http_status(:nope) end
+    end
+  end
+
   describe "report/2" do
     setup do
       ref = make_ref()

--- a/test/errata_test.exs
+++ b/test/errata_test.exs
@@ -362,7 +362,7 @@ defmodule ErrataTest do
     end
 
     test "raises ArgumentError for non-Errata values" do
-      assert_raise ArgumentError, ~r/expected an Errata error/, fn -> Errata.http_status(:nope) end
+      assert_raise ArgumentError, ~r/expected an Errata error/, fn -> Errata.http_status(nil) end
     end
   end
 


### PR DESCRIPTION
Closes #21.

Closes the boundary-classification loop the README already promised (domain → 4xx, infrastructure → 5xx) with a small, **framework-agnostic** mechanism — no Plug/Phoenix dependency.

## What

- Each generated error module gets an **overridable `http_status/1`** whose default is derived from the error's kind:
  - `:domain` → **422**, `:infrastructure` → **503**, `:general` → **500**
- A specific status can be set per type with the **`:http_status` option** (validated at compile time to be a `100..599` integer), or computed dynamically by **overriding `http_status/1`** (it's `defoverridable`).
- **`Errata.http_status/1`** delegates to the per-module function, so a boundary can map any Errata error to a status without knowing its type — and per-type overrides flow through automatically.

```elixir
defmodule MyApp.Orders.OrderNotFound do
  use Errata.DomainError, http_status: 404
end

def call(conn, {:error, error}) when Errata.is_error(error) do
  put_status(conn, Errata.http_status(error)) |> render("error.json", error: error)
end
```

## Decisions (per the issue's open questions)

- **Default table** (the part that freezes at 1.0): `:domain` → 422, `:infrastructure` → 503, `:general` → 500 — confirmed explicitly. Specific types are expected to override (e.g. `OrderNotFound` → 404); these are only the coarse catch-all defaults.
- **Override mechanism: both** — the `:http_status` `use` option for the simple constant case, and `defoverridable` for computing a status from `reason`/`context`.
- **Lives in both places** — generic `Errata.http_status/1` delegating to the per-module function (single source of truth).
- **Not a behaviour callback.** `http_status/1` is a plain overridable function; making it a formal `@callback` would cause user overrides (defined without `@impl`) to trip Elixir's `@impl` consistency warnings, given the generated module already uses `@impl` for the real callbacks.

## Semver

Additive. The function name/signature and the **default kind→status table** are the frozen public contract.

## Verification

- `mix test` — 14 doctests, 98 tests, 0 failures
- `mix format --check-formatted` — clean
- `mix credo --strict` — no issues
- `mix dialyzer` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
