### PR TITLE
Bump dev toolchain to Elixir 1.18.4 / OTP 27.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.16.1-otp-26
-erlang 26.2.1
+elixir 1.18.4-otp-27
+erlang 27.2


### PR DESCRIPTION
## What

Bumps the pinned development toolchain in `.tool-versions`:

```diff
-elixir 1.16.1-otp-26
-erlang 26.2.1
+elixir 1.18.4-otp-27
+erlang 27.2
```

## Why

The `Quality (format, credo, docs)` CI job runs **Elixir 1.18.4 / OTP 27.2** (`ci.yml`), but the repo pinned **1.16.1** for local development. The two formatter versions disagree on some constructs — which is exactly how an over-length line passed a local `mix format --check-formatted` yet failed CI on #28. Pinning local dev to match the Quality gate keeps `mix format`/credo/docs honest before pushing.

- `1.18.4` is the latest Elixir 1.18.x (confirmed against upstream tags).
- `27.2` is a compatible OTP 27 and matches the exact pair the Quality job uses; the `-otp-27` Elixir build is paired with an OTP-27 runtime, per the matched-pair requirement.
- The library's supported range is unchanged — `mix.exs` still declares `~> 1.15`, and the CI matrix still tests 1.15.8 through 1.18.4.

## Note

`CLAUDE.md` has a now-stale line ("Elixir 1.15 / OTP 26 … only runtime dependency is `jason`" — `telemetry` was added in #19), but it's gitignored in this repo, so it can't be corrected via a PR. Flagging it here in case you maintain that file out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
