### PR TITLE
Optional Jason + native JSON.Encoder support (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `JSON` encoder. This is backward compatible — anyone who depends on
   `Jason.encode!(error)` already has Jason in their own dependencies. (#30)
 
+### Upgrading
+- If your project calls `Jason` directly but relied on Errata to pull it in
+  transitively, add `{:jason, "~> 1.4"}` to your own dependencies, since Errata
+  no longer forces it into your dependency tree. On Elixir 1.18+ you can instead
+  use the built-in `JSON` module and drop the Jason dependency entirely.
+
 ## [1.0.0] - 2026-06-03
 
 First stable release. As of 1.0.0 the public API — the error struct shape, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+
+### Added
+- Native JSON support: on Elixir 1.18 and later, every error type now implements
+  the built-in `JSON.Encoder` protocol, so `JSON.encode!(error)` works with no
+  third-party dependencies. The built-in and Jason backends produce the same JSON
+  shape. (#30)
+
+### Changed
+- `jason` is now an *optional* dependency. Projects that have Jason continue to
+  get a generated `Jason.Encoder` implementation exactly as before; projects on
+  Elixir 1.18+ that don't use Jason can now drop it and rely on the built-in
+  `JSON` encoder. This is backward compatible — anyone who depends on
+  `Jason.encode!(error)` already has Jason in their own dependencies. (#30)
+
 ## [1.0.0] - 2026-06-03
 
 First stable release. As of 1.0.0 the public API — the error struct shape, the

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ With Errata you can:
   * **Classify errors** as domain, infrastructure, or general, and branch on
     that classification at system boundaries with the `Errata` guards.
   * **Serialize errors automatically** — every error type implements the
-    `String.Chars` and `Jason.Encoder` protocols.
+    `String.Chars` protocol and, depending on what's available, the built-in
+    `JSON.Encoder` (Elixir 1.18+) and/or `Jason.Encoder` protocols.
   * **Report errors at a boundary** — log an error with its fields as structured
     metadata, or emit a telemetry event for your own handler to forward to
     Sentry, a metrics backend, or wherever errors should go.
@@ -597,6 +598,28 @@ def deps do
   ]
 end
 ```
+
+### JSON encoding
+
+Errata encodes errors to JSON through whichever backend is available, so you
+generally don't need to configure anything:
+
+  * On **Elixir 1.18 and later**, error types implement the built-in
+    `JSON.Encoder` protocol, so `JSON.encode!(error)` works with no extra
+    dependencies.
+  * If [`jason`](https://hex.pm/packages/jason) is present, error types also
+    implement `Jason.Encoder`, so `Jason.encode!(error)` works as before. Jason
+    is an *optional* dependency — add it explicitly if you want it (for example
+    to use Jason on Elixir versions earlier than 1.18, or alongside the built-in
+    encoder):
+
+    ```elixir
+    {:jason, "~> 1.4"}
+    ```
+
+Both backends produce the same JSON shape. If neither is available (Elixir
+older than 1.18 without Jason), errors can still be converted to a plain map
+with `Errata.to_map/1`, which you can encode however you like.
 
 Documentation is generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm/errata/index.html).

--- a/lib/errata/errors.ex
+++ b/lib/errata/errors.ex
@@ -132,11 +132,17 @@ defmodule Errata.Errors do
     "#{message}: #{inspect(reason)}"
   end
 
-  @doc false
-  def to_json(error, opts) do
-    error
-    |> to_map()
-    |> Errata.JSON.encode(opts)
+  # Encode an error to JSON via the Jason backend. Only compiled when Jason is
+  # available; the generated `Jason.Encoder` impl (and therefore this function)
+  # is only emitted in that case, so the reference to `Jason.Encode` never
+  # produces an "undefined module" warning on Jason-less builds.
+  if Code.ensure_loaded?(Jason) do
+    @doc false
+    def to_json(error, opts) do
+      error
+      |> to_map()
+      |> Jason.Encode.map(opts)
+    end
   end
 
   @doc false
@@ -152,7 +158,7 @@ defmodule Errata.Errors do
     exception_def = define_exception(kind, opts)
     errata_error_impl = define_errata_error_callbacks()
     string_chars_impl = define_string_chars_impl(module_name)
-    jason_encoder_impl = define_jason_encoder_impl(module_name)
+    json_encoder_impls = define_json_encoder_impls(module_name)
 
     quote do
       unquote(attribute_defs)
@@ -162,7 +168,7 @@ defmodule Errata.Errors do
       unquote(exception_def)
       unquote(errata_error_impl)
       unquote(string_chars_impl)
-      unquote(jason_encoder_impl)
+      unquote(json_encoder_impls)
     end
   end
 
@@ -395,13 +401,39 @@ defmodule Errata.Errors do
     end
   end
 
-  defp define_jason_encoder_impl(error_module) do
-    quote do
-      defimpl Jason.Encoder, for: unquote(error_module) do
-        def encode(errata_error, opts) do
-          Errata.Errors.to_json(errata_error, opts)
+  # Emit a JSON encoder protocol impl for each backend that is available at
+  # compile time. On Elixir 1.18+ this includes the built-in `JSON.Encoder`; on
+  # any build where Jason is present (it is an optional dependency) it includes
+  # `Jason.Encoder`. Both encode the same `to_map/1` shape, so the JSON output is
+  # identical regardless of which backend a caller uses.
+  defp define_json_encoder_impls(error_module) do
+    jason_impl =
+      if Code.ensure_loaded?(Jason) do
+        quote do
+          defimpl Jason.Encoder, for: unquote(error_module) do
+            def encode(errata_error, opts) do
+              Errata.Errors.to_json(errata_error, opts)
+            end
+          end
         end
       end
+
+    native_impl =
+      if Code.ensure_loaded?(JSON) do
+        quote do
+          defimpl JSON.Encoder, for: unquote(error_module) do
+            def encode(errata_error, encoder) do
+              errata_error
+              |> Errata.Errors.to_map()
+              |> JSON.protocol_encode(encoder)
+            end
+          end
+        end
+      end
+
+    quote do
+      unquote(jason_impl)
+      unquote(native_impl)
     end
   end
 end

--- a/lib/errata/json.ex
+++ b/lib/errata/json.ex
@@ -1,9 +1,15 @@
 defmodule Errata.JSON do
   @moduledoc false
 
-  def encode(error_as_map, opts) do
-    Jason.Encode.map(error_as_map, opts)
-  end
+  # Errata supports two JSON backends: Elixir's built-in `JSON` module (available
+  # on Elixir 1.18+) and the optional `jason` dependency. Which are present is
+  # decided at compile time. `encodable?/1` is used to sanitize the `context` map
+  # at error-creation time (values that cannot be encoded are `inspect`'d), so it
+  # only needs *a* working backend — it prefers the built-in one and falls back
+  # to Jason.
+
+  @native Code.ensure_loaded?(JSON)
+  @jason Code.ensure_loaded?(Jason)
 
   def encodable?(map) when is_map(map) do
     Enum.all?(map, fn {k, v} ->
@@ -11,15 +17,46 @@ defmodule Errata.JSON do
     end)
   end
 
-  def encodable?(value) do
-    match?({:ok, _}, Jason.encode(value))
+  cond do
+    @native ->
+      def encodable?(value) do
+        JSON.encode!(value)
+        true
+      rescue
+        Protocol.UndefinedError -> false
+      end
+
+    @jason ->
+      def encodable?(value) do
+        match?({:ok, _}, Jason.encode(value))
+      end
+
+    true ->
+      # No JSON backend at all: sanitization is best-effort, so treat values as
+      # encodable and leave them untouched.
+      def encodable?(_value), do: true
   end
 
-  defimpl Jason.Encoder, for: Tuple do
-    def encode(data, options) when is_tuple(data) do
-      data
-      |> Tuple.to_list()
-      |> Jason.Encoder.List.encode(options)
+  # Tuples have no JSON representation in either backend by default; Errata
+  # encodes them as arrays so that tuple values in `context` serialize the same
+  # way regardless of which backend a caller uses.
+  if @jason do
+    defimpl Jason.Encoder, for: Tuple do
+      def encode(data, options) when is_tuple(data) do
+        data
+        |> Tuple.to_list()
+        |> Jason.Encoder.List.encode(options)
+      end
+    end
+  end
+
+  if @native do
+    defimpl JSON.Encoder, for: Tuple do
+      def encode(data, encoder) when is_tuple(data) do
+        data
+        |> Tuple.to_list()
+        |> JSON.protocol_encode(encoder)
+      end
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Errata.MixProject do
   use Mix.Project
 
-  @version "1.0.0"
+  @version "1.1.0"
   @source_url "https://github.com/jvoegele/errata"
 
   def project do
@@ -44,7 +44,7 @@ defmodule Errata.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:jason, ">= 1.3.0"},
+      {:jason, ">= 1.3.0", optional: true},
       {:telemetry, "~> 1.0"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},

--- a/test/errata/error_test.exs
+++ b/test/errata/error_test.exs
@@ -368,4 +368,36 @@ defmodule Errata.ErrorTest do
                Exception.format_mfa(current_module, current_function, current_function_arity)
     end
   end
+
+  # The built-in JSON module (and JSON.Encoder protocol) is only available on
+  # Elixir 1.18+; this block compiles away on earlier versions. It asserts the
+  # native backend produces the same JSON shape as the Jason backend above.
+  if Code.ensure_loaded?(JSON) do
+    describe "JSON.Encoder protocol implementation (built-in JSON):" do
+      require TestError
+
+      test "produces the same JSON shape as the Jason backend" do
+        error =
+          TestError.create(
+            reason: :to_believe,
+            context: %{meta: "data", danger: {:error, "tuple"}, pid: self()}
+          )
+
+        decoded = error |> JSON.encode!() |> JSON.decode!()
+
+        assert decoded["message"] == error.message
+        assert decoded["reason"] == to_string(error.reason)
+
+        assert %{"meta" => "data", "danger" => ["error", "tuple"], "pid" => pid_string} =
+                 decoded["context"]
+
+        assert pid_string =~ ~r(#PID<\d+\.\d+\.\d+>)
+
+        assert %{"file" => file, "module" => module} = decoded["env"]
+        assert file =~ ~r/error_test.exs$/
+        assert module == inspect(__MODULE__)
+        refute module =~ "Elixir."
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #30. Prompted by forum feedback from **cmo** on the [1.0.0 announcement thread](https://elixirforum.com/t/errata-structured-error-handling-for-elixir-1-0-0-released/75564).

## What

On **Elixir 1.18+**, every generated error type now implements the built-in `JSON.Encoder` protocol, so `JSON.encode!(error)` works with **no third-party dependencies**. `jason` becomes an **optional** dependency.

## How

- **`mix.exs`** — `{:jason, ">= 1.3.0", optional: true}`; version → `1.1.0`.
- **`lib/errata/errors.ex`** — `define_json_encoder_impls/1` emits, per error module, a `Jason.Encoder` impl when Jason is loaded and/or a `JSON.Encoder` impl when the built-in `JSON` is loaded (`Code.ensure_loaded?/1`, checked in the user's compile env). The native impl delegates to `to_map/1` then `JSON.protocol_encode/2`. The Jason-specific `to_json/2` is now compiled only when Jason is present, so Jason-less builds emit no "undefined `Jason.Encode`" warning.
- **`lib/errata/json.ex`** — `encodable?/1` (used to sanitize `context`) prefers the native backend, falls back to Jason, and assumes encodable if neither is present. Adds a native `JSON.Encoder` Tuple shim alongside the existing Jason one so tuples encode as arrays on both backends.

## Compatibility

Fully additive, no floor bump:
- Errata still supports `~> 1.15`; the native impl simply isn't generated below 1.18.
- **No breakage**: anyone calling `Jason.encode!(error)` already depends on Jason, so the Jason impl still generates for them.
- Both backends produce the **identical** 1.0-frozen JSON shape (tuple→array, pid→string, module names without the `Elixir.` prefix). A new native-backend test asserts this; it compiles away on < 1.18.

## Verification (Elixir 1.18.4 / OTP 27.2)

- `mix test` — 99 tests + 14 doctests, 0 failures
- `mix format --check-formatted` — clean
- `mix credo --strict` — no issues
- `mix dialyzer` — 0 errors
- `mix docs` — builds

## Caveat for reviewers

CI always has Jason (it's a test dep), so the "Jason fully absent" branch is exercised by the conditional-compile logic but not by an actual no-Jason build. A no-Jason CI matrix leg would close that gap and is a reasonable optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)