### PR TITLE
feat: add support for native Elixir JSON module

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Each `use` accepts a few options:
 
 Whichever module you use, the resulting error type is an exception struct that
 conforms to the `t:Errata.error/0` type, implements the `Errata.Error`
-behaviour, and provides `String.Chars` and `Jason.Encoder` implementations so
+behaviour, and provides `String.Chars`, `JSON.Encoder`, and `Jason.Encoder` implementations so
 that it can be rendered as a string or encoded as JSON automatically.
 
 ## Creating errors as return values

--- a/lib/errata/error.ex
+++ b/lib/errata/error.ex
@@ -184,7 +184,7 @@ defmodule Errata.Error do
   exception while preserving its original stacktrace:
 
       try do
-        Jason.decode!(payload)
+        JSON.decode!(payload)
       rescue
         e ->
           {:error, MyApp.InvalidPayload.wrap(e, stacktrace: __STACKTRACE__, reason: :malformed_json)}

--- a/lib/errata/errors.ex
+++ b/lib/errata/errors.ex
@@ -133,13 +133,6 @@ defmodule Errata.Errors do
   end
 
   @doc false
-  def to_json(error, opts) do
-    error
-    |> to_map()
-    |> Errata.JSON.encode(opts)
-  end
-
-  @doc false
   def define(kind, module_name, opts \\ [])
       when kind in [:domain, :infrastructure, :general] and is_atom(module_name) do
     reasons = Keyword.get(opts, :reasons)
@@ -152,7 +145,7 @@ defmodule Errata.Errors do
     exception_def = define_exception(kind, opts)
     errata_error_impl = define_errata_error_callbacks()
     string_chars_impl = define_string_chars_impl(module_name)
-    jason_encoder_impl = define_jason_encoder_impl(module_name)
+    encoder_impls = define_encoder_impls(module_name)
 
     quote do
       unquote(attribute_defs)
@@ -162,7 +155,7 @@ defmodule Errata.Errors do
       unquote(exception_def)
       unquote(errata_error_impl)
       unquote(string_chars_impl)
-      unquote(jason_encoder_impl)
+      unquote_splicing(encoder_impls)
     end
   end
 
@@ -395,11 +388,20 @@ defmodule Errata.Errors do
     end
   end
 
-  defp define_jason_encoder_impl(error_module) do
-    quote do
-      defimpl Jason.Encoder, for: unquote(error_module) do
-        def encode(errata_error, opts) do
-          Errata.Errors.to_json(errata_error, opts)
+  defp define_encoder_impls(error_module) do
+    configs = [
+      {JSON.Encoder, JSON.Encoder.Map, :encode},
+      {Jason.Encoder, Jason.Encode, :map}
+    ]
+
+    for {protocol, mod, fun} <- configs, Code.ensure_loaded?(protocol) do
+      quote do
+        defimpl unquote(protocol), for: unquote(error_module) do
+          def encode(errata_error, opts_or_encoder) do
+            errata_error
+            |> Errata.Errors.to_map()
+            |> unquote(mod).unquote(fun)(opts_or_encoder)
+          end
         end
       end
     end

--- a/lib/errata/json.ex
+++ b/lib/errata/json.ex
@@ -1,10 +1,6 @@
 defmodule Errata.JSON do
   @moduledoc false
 
-  def encode(error_as_map, opts) do
-    Jason.Encode.map(error_as_map, opts)
-  end
-
   def encodable?(map) when is_map(map) do
     Enum.all?(map, fn {k, v} ->
       (is_atom(k) or is_binary(k)) and encodable?(v)
@@ -12,14 +8,34 @@ defmodule Errata.JSON do
   end
 
   def encodable?(value) do
-    match?({:ok, _}, Jason.encode(value))
+    if Code.ensure_loaded?(JSON) do
+      try do
+        JSON.encode_to_iodata!(value)
+        true
+      rescue
+        _ -> false
+      end
+    else
+      if Code.ensure_loaded?(Jason) do
+        match?({:ok, _}, Jason.encode(value))
+      else
+        false
+      end
+    end
   end
 
-  defimpl Jason.Encoder, for: Tuple do
-    def encode(data, options) when is_tuple(data) do
-      data
-      |> Tuple.to_list()
-      |> Jason.Encoder.List.encode(options)
+  for {protocol, mod} <- [
+        {JSON.Encoder, JSON.Encoder.List},
+        {Jason.Encoder, Jason.Encoder.List}
+      ] do
+    if Code.ensure_loaded?(protocol) do
+      defimpl protocol, for: Tuple do
+        def encode(data, opts_or_encoder) when is_tuple(data) do
+          data
+          |> Tuple.to_list()
+          |> unquote(mod).encode(opts_or_encoder)
+        end
+      end
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule Errata.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:jason, ">= 1.3.0"},
+      {:jason, ">= 1.3.0", optional: true},
       {:telemetry, "~> 1.0"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},

--- a/test/errata/error_test.exs
+++ b/test/errata/error_test.exs
@@ -340,32 +340,71 @@ defmodule Errata.ErrorTest do
     end
   end
 
-  describe "Jason.Encoder protocol implementation:" do
-    require TestError
+  if Code.ensure_loaded?(Jason.Encoder) do
+    describe "Jason.Encoder protocol implementation:" do
+      require TestError
 
-    test "produces JSON data for the relevant fields" do
-      error =
-        TestError.create(
-          reason: :to_believe,
-          context: %{meta: "data", danger: {:error, "tuple"}, pid: self()}
-        )
+      test "produces JSON data for the relevant fields" do
+        error =
+          TestError.create(
+            reason: :to_believe,
+            context: %{meta: "data", danger: {:error, "tuple"}, pid: self()}
+          )
 
-      assert {:ok, decoded} = error |> Jason.encode!() |> Jason.decode(keys: :atoms)
-      assert decoded.message == error.message
-      assert decoded.reason == to_string(error.reason)
-      assert %{meta: "data", danger: ["error", "tuple"], pid: pid_string} = decoded.context
-      assert pid_string =~ ~r(#PID<\d+\.\d+\.\d+>)
+        assert {:ok, decoded} = error |> Jason.encode!() |> Jason.decode(keys: :atoms)
+        assert decoded.message == error.message
+        assert decoded.reason == to_string(error.reason)
+        assert %{meta: "data", danger: ["error", "tuple"], pid: pid_string} = decoded.context
+        assert pid_string =~ ~r(#PID<\d+\.\d+\.\d+>)
 
-      assert %{file: file, line: line, module: module, function: function} = decoded.env
-      assert file =~ ~r/error_test.exs$/
-      assert is_integer(line)
-      assert module == inspect(__MODULE__)
-      refute module =~ "Elixir."
+        assert %{file: file, line: line, module: module, function: function} = decoded.env
+        assert file =~ ~r/error_test.exs$/
+        assert is_integer(line)
+        assert module == inspect(__MODULE__)
+        refute module =~ "Elixir."
 
-      %{module: current_module, function: {current_function, current_function_arity}} = __ENV__
+        %{module: current_module, function: {current_function, current_function_arity}} = __ENV__
 
-      assert function ==
-               Exception.format_mfa(current_module, current_function, current_function_arity)
+        assert function ==
+                 Exception.format_mfa(current_module, current_function, current_function_arity)
+      end
+    end
+  end
+
+  if Code.ensure_loaded?(JSON.Encoder) do
+    describe "JSON.Encoder protocol implementation:" do
+      require TestError
+
+      test "produces JSON data for the relevant fields" do
+        error =
+          TestError.create(
+            reason: :to_believe,
+            context: %{meta: "data", danger: {:error, "tuple"}, pid: self()}
+          )
+
+        assert decoded =
+                 error |> JSON.encode_to_iodata!() |> IO.iodata_to_binary() |> JSON.decode!()
+
+        # JSON library decodes keys as strings by default
+        assert decoded["message"] == error.message
+        assert decoded["reason"] == to_string(error.reason)
+
+        context = decoded["context"]
+        assert context["meta"] == "data"
+        assert context["danger"] == ["error", "tuple"]
+        assert context["pid"] =~ ~r(#PID<\d+\.\d+\.\d+>)
+
+        env = decoded["env"]
+        assert env["file"] =~ ~r/error_test.exs$/
+        assert is_integer(env["line"])
+        assert env["module"] == inspect(__MODULE__)
+        refute env["module"] =~ "Elixir."
+
+        %{module: current_module, function: {current_function, current_function_arity}} = __ENV__
+
+        assert env["function"] ==
+                 Exception.format_mfa(current_module, current_function, current_function_arity)
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds support for the native `JSON` module and `JSON.Encoder` protocol introduced in Elixir 1.18.

### Changes:
- **`mix.exs`**: `jason` is now an optional dependency.
- **`lib/errata/errors.ex`**: Conditionally generates `JSON.Encoder` and/or `Jason.Encoder` implementations based on what is available at compile-time.
- **`lib/errata/json.ex`**: Prioritizes native `JSON` for internal encodability checks and provides `Tuple` encoding support for both protocols.
- **`README.md`**: Updated documentation to reflect support for native JSON.
- **`test/errata/error_test.exs`**: Tests both protocols when available.

### Tradeoffs:
- Uses conditional compilation (`Code.ensure_loaded?`) to maintain backward compatibility with Elixir 1.15-1.17 and applications still using `Jason`.
- Zero-dependency for Elixir 1.18+ users who don't need `Jason`.

### Compatibility:
- Works on Elixir 1.15+ (falls back to `Jason`).
- Automatically leverages native performance on Elixir 1.18+ / OTP 27.
